### PR TITLE
New clang-format file applied for rocm2.5

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -23,12 +23,14 @@ DisableFormat:   false
 Standard: Cpp11
 
 AccessModifierOffset: -4
-AlignAfterOpenBracket: true
+AlignAfterOpenBracket: Align
 AlignConsecutiveAssignments: true
 AlignConsecutiveDeclarations: true
-AlignEscapedNewlinesLeft: true
+AlignEscapedNewlines: Left
 AlignOperands:   true
 AlignTrailingComments: false
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
 AllowAllParametersOfDeclarationOnNextLine: true
 AllowShortBlocksOnASingleLine: false
 AllowShortCaseLabelsOnASingleLine: false
@@ -46,6 +48,7 @@ BinPackParameters: false
 BreakBeforeBraces: Custom
 # Control of individual brace wrapping cases
 BraceWrapping: {
+    AfterCaseLabel: 'true'
     AfterClass: 'true'
     AfterControlStatement: 'true'
     AfterEnum : 'true'
@@ -72,11 +75,12 @@ ConstructorInitializerAllOnOneLineOrOnePerLine: false
 ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
-#SpaceBeforeCpp11BracedList: false
+SpaceBeforeCpp11BracedList: false
 DerivePointerAlignment: false
 ExperimentalAutoDetectBinPacking: false
 ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
 IndentCaseLabels: false
+IndentPPDirectives: None
 #FixNamespaceComments: true
 IndentWrappedFunctionNames: true
 KeepEmptyLinesAtTheStartOfBlocks: true
@@ -116,5 +120,4 @@ SortIncludes: true
 ReflowComments: false
 
 #IncludeBlocks: Preserve
-#IndentPPDirectives: AfterHash
 ---

--- a/clients/include/testing_axpyi.hpp
+++ b/clients/include/testing_axpyi.hpp
@@ -48,10 +48,10 @@ void testing_axpyi_bad_arg(void)
     std::unique_ptr<handle_struct> unique_ptr_handle(new handle_struct);
     rocsparse_handle               handle = unique_ptr_handle->handle;
 
-    auto dxVal_managed = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+    auto dxVal_managed = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
     auto dxInd_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
-    auto dy_managed = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+    auto dy_managed = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
 
     T*             dxVal = (T*)dxVal_managed.get();
     rocsparse_int* dxInd = (rocsparse_int*)dxInd_managed.get();
@@ -117,10 +117,10 @@ rocsparse_status testing_axpyi(Arguments argus)
     if(nnz <= 0)
     {
         auto dxInd_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
         auto dxVal_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
-        auto dy_managed = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+        auto dy_managed = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
 
         rocsparse_int* dxInd = (rocsparse_int*)dxInd_managed.get();
         T*             dxVal = (T*)dxVal_managed.get();
@@ -167,11 +167,11 @@ rocsparse_status testing_axpyi(Arguments argus)
 
     // allocate memory on device
     auto dxInd_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * nnz), device_free};
-    auto dxVal_managed   = rocsparse_unique_ptr {device_malloc(sizeof(T) * nnz), device_free};
-    auto dy_1_managed    = rocsparse_unique_ptr {device_malloc(sizeof(T) * N), device_free};
-    auto dy_2_managed    = rocsparse_unique_ptr {device_malloc(sizeof(T) * N), device_free};
-    auto d_alpha_managed = rocsparse_unique_ptr {device_malloc(sizeof(T)), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * nnz), device_free};
+    auto dxVal_managed   = rocsparse_unique_ptr{device_malloc(sizeof(T) * nnz), device_free};
+    auto dy_1_managed    = rocsparse_unique_ptr{device_malloc(sizeof(T) * N), device_free};
+    auto dy_2_managed    = rocsparse_unique_ptr{device_malloc(sizeof(T) * N), device_free};
+    auto d_alpha_managed = rocsparse_unique_ptr{device_malloc(sizeof(T)), device_free};
 
     rocsparse_int* dxInd   = (rocsparse_int*)dxInd_managed.get();
     T*             dxVal   = (T*)dxVal_managed.get();

--- a/clients/include/testing_coo2csr.hpp
+++ b/clients/include/testing_coo2csr.hpp
@@ -48,9 +48,9 @@ void testing_coo2csr_bad_arg(void)
     rocsparse_handle               handle = unique_ptr_handle->handle;
 
     auto coo_row_ind_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
     auto csr_row_ptr_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
 
     rocsparse_int* coo_row_ind = (rocsparse_int*)coo_row_ind_managed.get();
     rocsparse_int* csr_row_ptr = (rocsparse_int*)csr_row_ptr_managed.get();
@@ -124,9 +124,9 @@ rocsparse_status testing_coo2csr(Arguments argus)
     if(m <= 0 || n <= 0 || nnz <= 0)
     {
         auto coo_row_ind_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
         auto csr_row_ptr_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
 
         rocsparse_int* coo_row_ind = (rocsparse_int*)coo_row_ind_managed.get();
         rocsparse_int* csr_row_ptr = (rocsparse_int*)csr_row_ptr_managed.get();
@@ -218,9 +218,9 @@ rocsparse_status testing_coo2csr(Arguments argus)
 
     // Allocate memory on the device
     auto dcoo_row_ind_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * nnz), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * nnz), device_free};
     auto dcsr_row_ptr_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * (m + 1)), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * (m + 1)), device_free};
 
     rocsparse_int* dcoo_row_ind = (rocsparse_int*)dcoo_row_ind_managed.get();
     rocsparse_int* dcsr_row_ptr = (rocsparse_int*)dcsr_row_ptr_managed.get();

--- a/clients/include/testing_coomv.hpp
+++ b/clients/include/testing_coomv.hpp
@@ -55,12 +55,12 @@ void testing_coomv_bad_arg(void)
     rocsparse_mat_descr           descr = unique_ptr_descr->descr;
 
     auto drow_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
     auto dcol_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
-    auto dval_managed = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
-    auto dx_managed   = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
-    auto dy_managed   = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+    auto dval_managed = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+    auto dx_managed   = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+    auto dy_managed   = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
 
     rocsparse_int* drow = (rocsparse_int*)drow_managed.get();
     rocsparse_int* dcol = (rocsparse_int*)dcol_managed.get();
@@ -196,13 +196,12 @@ rocsparse_status testing_coomv(Arguments argus)
     if(m <= 0 || n <= 0 || nnz <= 0)
     {
         auto drow_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
         auto dcol_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
-        auto dval_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
-        auto dx_managed = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
-        auto dy_managed = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+        auto dval_managed = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+        auto dx_managed   = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+        auto dy_managed   = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
 
         rocsparse_int* drow = (rocsparse_int*)drow_managed.get();
         rocsparse_int* dcol = (rocsparse_int*)dcol_managed.get();
@@ -304,15 +303,15 @@ rocsparse_status testing_coomv(Arguments argus)
 
     // allocate memory on device
     auto drow_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * nnz), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * nnz), device_free};
     auto dcol_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * nnz), device_free};
-    auto dval_managed    = rocsparse_unique_ptr {device_malloc(sizeof(T) * nnz), device_free};
-    auto dx_managed      = rocsparse_unique_ptr {device_malloc(sizeof(T) * n), device_free};
-    auto dy_1_managed    = rocsparse_unique_ptr {device_malloc(sizeof(T) * m), device_free};
-    auto dy_2_managed    = rocsparse_unique_ptr {device_malloc(sizeof(T) * m), device_free};
-    auto d_alpha_managed = rocsparse_unique_ptr {device_malloc(sizeof(T)), device_free};
-    auto d_beta_managed  = rocsparse_unique_ptr {device_malloc(sizeof(T)), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * nnz), device_free};
+    auto dval_managed    = rocsparse_unique_ptr{device_malloc(sizeof(T) * nnz), device_free};
+    auto dx_managed      = rocsparse_unique_ptr{device_malloc(sizeof(T) * n), device_free};
+    auto dy_1_managed    = rocsparse_unique_ptr{device_malloc(sizeof(T) * m), device_free};
+    auto dy_2_managed    = rocsparse_unique_ptr{device_malloc(sizeof(T) * m), device_free};
+    auto d_alpha_managed = rocsparse_unique_ptr{device_malloc(sizeof(T)), device_free};
+    auto d_beta_managed  = rocsparse_unique_ptr{device_malloc(sizeof(T)), device_free};
 
     rocsparse_int* drow    = (rocsparse_int*)drow_managed.get();
     rocsparse_int* dcol    = (rocsparse_int*)dcol_managed.get();

--- a/clients/include/testing_coosort.hpp
+++ b/clients/include/testing_coosort.hpp
@@ -51,13 +51,13 @@ void testing_coosort_bad_arg(void)
     size_t buffer_size = 0;
 
     auto coo_row_ind_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
     auto coo_col_ind_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
     auto perm_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
     auto buffer_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(char) * safe_size), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(char) * safe_size), device_free};
 
     rocsparse_int* coo_row_ind = (rocsparse_int*)coo_row_ind_managed.get();
     rocsparse_int* coo_col_ind = (rocsparse_int*)coo_col_ind_managed.get();
@@ -226,13 +226,13 @@ rocsparse_status testing_coosort(Arguments argus)
     if(m <= 0 || n <= 0 || nnz <= 0)
     {
         auto coo_row_ind_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
         auto coo_col_ind_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
         auto perm_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
         auto buffer_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(char) * safe_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(char) * safe_size), device_free};
 
         rocsparse_int* coo_row_ind = (rocsparse_int*)coo_row_ind_managed.get();
         rocsparse_int* coo_col_ind = (rocsparse_int*)coo_col_ind_managed.get();
@@ -409,14 +409,14 @@ rocsparse_status testing_coosort(Arguments argus)
 
     // Allocate memory on the device
     auto dcoo_row_ind_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * nnz), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * nnz), device_free};
     auto dcoo_col_ind_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * nnz), device_free};
-    auto dcoo_val_managed = rocsparse_unique_ptr {device_malloc(sizeof(float) * nnz), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * nnz), device_free};
+    auto dcoo_val_managed = rocsparse_unique_ptr{device_malloc(sizeof(float) * nnz), device_free};
     auto dcoo_val_sorted_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(float) * nnz), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(float) * nnz), device_free};
     auto dperm_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * nnz), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * nnz), device_free};
 
     rocsparse_int* dcoo_row_ind    = (rocsparse_int*)dcoo_row_ind_managed.get();
     rocsparse_int* dcoo_col_ind    = (rocsparse_int*)dcoo_col_ind_managed.get();
@@ -454,7 +454,7 @@ rocsparse_status testing_coosort(Arguments argus)
 
         // Allocate buffer on the device
         auto dbuffer_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(char) * buffer_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(char) * buffer_size), device_free};
 
         void* dbuffer = (void*)dbuffer_managed.get();
 
@@ -526,7 +526,7 @@ rocsparse_status testing_coosort(Arguments argus)
         rocsparse_coosort_buffer_size(handle, m, n, nnz, dcoo_row_ind, dcoo_col_ind, &buffer_size);
 
         auto dbuffer_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(char) * buffer_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(char) * buffer_size), device_free};
         void* dbuffer = (void*)dbuffer_managed.get();
 
         for(rocsparse_int iter = 0; iter < number_cold_calls; ++iter)

--- a/clients/include/testing_csr2coo.hpp
+++ b/clients/include/testing_csr2coo.hpp
@@ -48,9 +48,9 @@ void testing_csr2coo_bad_arg(void)
     rocsparse_handle               handle = unique_ptr_handle->handle;
 
     auto csr_row_ptr_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
     auto coo_row_ind_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
 
     rocsparse_int* csr_row_ptr = (rocsparse_int*)csr_row_ptr_managed.get();
     rocsparse_int* coo_row_ind = (rocsparse_int*)coo_row_ind_managed.get();
@@ -124,9 +124,9 @@ rocsparse_status testing_csr2coo(Arguments argus)
     if(m <= 0 || n <= 0 || nnz <= 0)
     {
         auto csr_row_ptr_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
         auto coo_row_ind_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
 
         rocsparse_int* csr_row_ptr = (rocsparse_int*)csr_row_ptr_managed.get();
         rocsparse_int* coo_row_ind = (rocsparse_int*)coo_row_ind_managed.get();
@@ -205,9 +205,9 @@ rocsparse_status testing_csr2coo(Arguments argus)
 
     // Allocate memory on the device
     auto dcsr_row_ptr_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * (m + 1)), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * (m + 1)), device_free};
     auto dcoo_row_ind_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * nnz), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * nnz), device_free};
 
     rocsparse_int* dcsr_row_ptr = (rocsparse_int*)dcsr_row_ptr_managed.get();
     rocsparse_int* dcoo_row_ind = (rocsparse_int*)dcoo_row_ind_managed.get();

--- a/clients/include/testing_csr2csc.hpp
+++ b/clients/include/testing_csr2csc.hpp
@@ -52,17 +52,17 @@ void testing_csr2csc_bad_arg(void)
     rocsparse_handle               handle = unique_ptr_handle->handle;
 
     auto csr_row_ptr_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
     auto csr_col_ind_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
-    auto csr_val_managed = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+    auto csr_val_managed = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
     auto csc_row_ind_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
     auto csc_col_ptr_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
-    auto csc_val_managed = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+    auto csc_val_managed = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
     auto buffer_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(char) * safe_size), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(char) * safe_size), device_free};
 
     rocsparse_int* csr_row_ptr = (rocsparse_int*)csr_row_ptr_managed.get();
     rocsparse_int* csr_col_ind = (rocsparse_int*)csr_col_ind_managed.get();
@@ -327,19 +327,19 @@ rocsparse_status testing_csr2csc(Arguments argus)
     if(m <= 0 || n <= 0 || nnz <= 0)
     {
         auto csr_row_ptr_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
         auto csr_col_ind_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
         auto csr_val_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
         auto csc_row_ind_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
         auto csc_col_ptr_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
         auto csc_val_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
         auto buffer_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(char) * safe_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(char) * safe_size), device_free};
 
         rocsparse_int* csr_row_ptr = (rocsparse_int*)csr_row_ptr_managed.get();
         rocsparse_int* csr_col_ind = (rocsparse_int*)csr_col_ind_managed.get();
@@ -457,15 +457,15 @@ rocsparse_status testing_csr2csc(Arguments argus)
 
     // Allocate memory on the device
     auto dcsr_row_ptr_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * (m + 1)), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * (m + 1)), device_free};
     auto dcsr_col_ind_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * nnz), device_free};
-    auto dcsr_val_managed = rocsparse_unique_ptr {device_malloc(sizeof(T) * nnz), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * nnz), device_free};
+    auto dcsr_val_managed = rocsparse_unique_ptr{device_malloc(sizeof(T) * nnz), device_free};
     auto dcsc_row_ind_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * nnz), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * nnz), device_free};
     auto dcsc_col_ptr_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * (n + 1)), device_free};
-    auto dcsc_val_managed = rocsparse_unique_ptr {device_malloc(sizeof(T) * nnz), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * (n + 1)), device_free};
+    auto dcsc_val_managed = rocsparse_unique_ptr{device_malloc(sizeof(T) * nnz), device_free};
 
     rocsparse_int* dcsr_row_ptr = (rocsparse_int*)dcsr_row_ptr_managed.get();
     rocsparse_int* dcsr_col_ind = (rocsparse_int*)dcsr_col_ind_managed.get();
@@ -499,7 +499,7 @@ rocsparse_status testing_csr2csc(Arguments argus)
         handle, m, n, nnz, dcsr_row_ptr, dcsr_col_ind, action, &size));
 
     // Allocate buffer on the device
-    auto dbuffer_managed = rocsparse_unique_ptr {device_malloc(sizeof(char) * size), device_free};
+    auto dbuffer_managed = rocsparse_unique_ptr{device_malloc(sizeof(char) * size), device_free};
 
     void* dbuffer = (void*)dbuffer_managed.get();
 

--- a/clients/include/testing_csr2ell.hpp
+++ b/clients/include/testing_csr2ell.hpp
@@ -58,10 +58,10 @@ void testing_csr2ell_bad_arg(void)
     rocsparse_mat_descr           ell_descr = unique_ptr_ell_descr->descr;
 
     auto csr_row_ptr_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
     auto csr_col_ind_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
-    auto csr_val_managed = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+    auto csr_val_managed = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
 
     rocsparse_int* csr_row_ptr = (rocsparse_int*)csr_row_ptr_managed.get();
     rocsparse_int* csr_col_ind = (rocsparse_int*)csr_col_ind_managed.get();
@@ -125,8 +125,8 @@ void testing_csr2ell_bad_arg(void)
 
     // Allocate memory for ELL storage format
     auto ell_col_ind_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
-    auto ell_val_managed = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+    auto ell_val_managed = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
 
     rocsparse_int* ell_col_ind = (rocsparse_int*)ell_col_ind_managed.get();
     T*             ell_val     = (T*)ell_val_managed.get();
@@ -330,14 +330,14 @@ rocsparse_status testing_csr2ell(Arguments argus)
     if(m <= 0 || n <= 0 || nnz <= 0)
     {
         auto csr_row_ptr_managed
-            = (m > 0) ? rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * (m + 1)),
-                                              device_free}
-                      : rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size),
-                                              device_free};
+            = (m > 0) ? rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * (m + 1)),
+                                             device_free}
+                      : rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size),
+                                             device_free};
         auto csr_col_ind_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
         auto csr_val_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
 
         rocsparse_int* csr_row_ptr = (rocsparse_int*)csr_row_ptr_managed.get();
         rocsparse_int* csr_col_ind = (rocsparse_int*)csr_col_ind_managed.get();
@@ -367,9 +367,9 @@ rocsparse_status testing_csr2ell(Arguments argus)
         }
 
         auto ell_col_ind_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
         auto ell_val_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
 
         rocsparse_int* ell_col_ind = (rocsparse_int*)ell_col_ind_managed.get();
         T*             ell_val     = (T*)ell_val_managed.get();
@@ -463,10 +463,10 @@ rocsparse_status testing_csr2ell(Arguments argus)
 
     // Allocate memory on the device
     auto dcsr_row_ptr_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * (m + 1)), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * (m + 1)), device_free};
     auto dcsr_col_ind_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * nnz), device_free};
-    auto dcsr_val_managed = rocsparse_unique_ptr {device_malloc(sizeof(T) * nnz), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * nnz), device_free};
+    auto dcsr_val_managed = rocsparse_unique_ptr{device_malloc(sizeof(T) * nnz), device_free};
 
     rocsparse_int* dcsr_row_ptr = (rocsparse_int*)dcsr_row_ptr_managed.get();
     rocsparse_int* dcsr_col_ind = (rocsparse_int*)dcsr_col_ind_managed.get();
@@ -543,9 +543,9 @@ rocsparse_status testing_csr2ell(Arguments argus)
 
         // Allocate ELL device memory
         auto dell_col_ind_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * ell_nnz), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * ell_nnz), device_free};
         auto dell_val_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(T) * ell_nnz), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(T) * ell_nnz), device_free};
 
         rocsparse_int* dell_col_ind = (rocsparse_int*)dell_col_ind_managed.get();
         T*             dell_val     = (T*)dell_val_managed.get();
@@ -584,10 +584,10 @@ rocsparse_status testing_csr2ell(Arguments argus)
             rocsparse_csr2ell_width(handle, m, csr_descr, dcsr_row_ptr, ell_descr, &ell_width);
             rocsparse_int ell_nnz = ell_width * m;
 
-            auto dell_col_ind_managed = rocsparse_unique_ptr {
-                device_malloc(sizeof(rocsparse_int) * ell_nnz), device_free};
+            auto dell_col_ind_managed
+                = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * ell_nnz), device_free};
             auto dell_val_managed
-                = rocsparse_unique_ptr {device_malloc(sizeof(T) * ell_nnz), device_free};
+                = rocsparse_unique_ptr{device_malloc(sizeof(T) * ell_nnz), device_free};
 
             rocsparse_int* dell_col_ind = (rocsparse_int*)dell_col_ind_managed.get();
             T*             dell_val     = (T*)dell_val_managed.get();
@@ -611,10 +611,10 @@ rocsparse_status testing_csr2ell(Arguments argus)
             rocsparse_csr2ell_width(handle, m, csr_descr, dcsr_row_ptr, ell_descr, &ell_width);
             rocsparse_int ell_nnz = ell_width * m;
 
-            auto dell_col_ind_managed = rocsparse_unique_ptr {
-                device_malloc(sizeof(rocsparse_int) * ell_nnz), device_free};
+            auto dell_col_ind_managed
+                = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * ell_nnz), device_free};
             auto dell_val_managed
-                = rocsparse_unique_ptr {device_malloc(sizeof(T) * ell_nnz), device_free};
+                = rocsparse_unique_ptr{device_malloc(sizeof(T) * ell_nnz), device_free};
 
             rocsparse_int* dell_col_ind = (rocsparse_int*)dell_col_ind_managed.get();
             T*             dell_val     = (T*)dell_val_managed.get();

--- a/clients/include/testing_csr2hyb.hpp
+++ b/clients/include/testing_csr2hyb.hpp
@@ -74,10 +74,10 @@ void testing_csr2hyb_bad_arg(void)
     rocsparse_hyb_mat           hyb = unique_ptr_hyb->hyb;
 
     auto csr_row_ptr_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
     auto csr_col_ind_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
-    auto csr_val_managed = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+    auto csr_val_managed = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
 
     rocsparse_int* csr_row_ptr = (rocsparse_int*)csr_row_ptr_managed.get();
     rocsparse_int* csr_col_ind = (rocsparse_int*)csr_col_ind_managed.get();
@@ -204,11 +204,11 @@ rocsparse_status testing_csr2hyb(Arguments argus)
     if(m <= 0 || n <= 0 || nnz <= 0)
     {
         auto csr_row_ptr_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
         auto csr_col_ind_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
         auto csr_val_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
 
         rocsparse_int* csr_row_ptr = (rocsparse_int*)csr_row_ptr_managed.get();
         rocsparse_int* csr_col_ind = (rocsparse_int*)csr_col_ind_managed.get();
@@ -294,10 +294,10 @@ rocsparse_status testing_csr2hyb(Arguments argus)
 
     // Allocate memory on the device
     auto dcsr_row_ptr_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * (m + 1)), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * (m + 1)), device_free};
     auto dcsr_col_ind_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * nnz), device_free};
-    auto dcsr_val_managed = rocsparse_unique_ptr {device_malloc(sizeof(T) * nnz), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * nnz), device_free};
+    auto dcsr_val_managed = rocsparse_unique_ptr{device_malloc(sizeof(T) * nnz), device_free};
 
     rocsparse_int* dcsr_row_ptr = (rocsparse_int*)dcsr_row_ptr_managed.get();
     rocsparse_int* dcsr_col_ind = (rocsparse_int*)dcsr_col_ind_managed.get();

--- a/clients/include/testing_csrilu0.hpp
+++ b/clients/include/testing_csrilu0.hpp
@@ -57,12 +57,12 @@ void testing_csrilu0_bad_arg(void)
     rocsparse_mat_info               info = unique_ptr_mat_info->info;
 
     auto dptr_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
     auto dcol_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
-    auto dval_managed = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+    auto dval_managed = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
     auto dbuffer_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(char) * safe_size), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(char) * safe_size), device_free};
 
     rocsparse_int* dptr    = (rocsparse_int*)dptr_managed.get();
     rocsparse_int* dcol    = (rocsparse_int*)dcol_managed.get();
@@ -344,13 +344,12 @@ rocsparse_status testing_csrilu0(Arguments argus)
     if(m <= 0 || nnz <= 0)
     {
         auto dptr_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
         auto dcol_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
-        auto dval_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+        auto dval_managed = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
         auto buffer_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(char) * safe_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(char) * safe_size), device_free};
 
         rocsparse_int* dptr   = (rocsparse_int*)dptr_managed.get();
         rocsparse_int* dcol   = (rocsparse_int*)dcol_managed.get();
@@ -483,12 +482,12 @@ rocsparse_status testing_csrilu0(Arguments argus)
 
     // Allocate memory on device
     auto dptr_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * (m + 1)), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * (m + 1)), device_free};
     auto dcol_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * nnz), device_free};
-    auto dval_managed = rocsparse_unique_ptr {device_malloc(sizeof(T) * nnz), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * nnz), device_free};
+    auto dval_managed = rocsparse_unique_ptr{device_malloc(sizeof(T) * nnz), device_free};
     auto d_position_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int)), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int)), device_free};
 
     rocsparse_int* dptr       = (rocsparse_int*)dptr_managed.get();
     rocsparse_int* dcol       = (rocsparse_int*)dcol_managed.get();
@@ -514,7 +513,7 @@ rocsparse_status testing_csrilu0(Arguments argus)
         rocsparse_csrilu0_buffer_size(handle, m, nnz, descr, dval, dptr, dcol, info, &size));
 
     // Allocate buffer on the device
-    auto dbuffer_managed = rocsparse_unique_ptr {device_malloc(sizeof(char) * size), device_free};
+    auto dbuffer_managed = rocsparse_unique_ptr{device_malloc(sizeof(char) * size), device_free};
 
     void* dbuffer = (void*)dbuffer_managed.get();
 

--- a/clients/include/testing_csrilusv.hpp
+++ b/clients/include/testing_csrilusv.hpp
@@ -77,12 +77,12 @@ rocsparse_status testing_csrilusv(Arguments argus)
 
     // Allocate memory on device
     auto dptr_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * (m + 1)), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * (m + 1)), device_free};
     auto dcol_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * nnz), device_free};
-    auto dval_managed = rocsparse_unique_ptr {device_malloc(sizeof(T) * nnz), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * nnz), device_free};
+    auto dval_managed = rocsparse_unique_ptr{device_malloc(sizeof(T) * nnz), device_free};
     auto d_position_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int)), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int)), device_free};
 
     rocsparse_int* dptr       = (rocsparse_int*)dptr_managed.get();
     rocsparse_int* dcol       = (rocsparse_int*)dcol_managed.get();
@@ -109,7 +109,7 @@ rocsparse_status testing_csrilusv(Arguments argus)
         rocsparse_csrilu0_buffer_size(handle, m, nnz, descr_M, dval, dptr, dcol, info, &size));
 
     // Allocate buffer on the device
-    auto dbuffer_managed = rocsparse_unique_ptr {device_malloc(sizeof(char) * size), device_free};
+    auto dbuffer_managed = rocsparse_unique_ptr{device_malloc(sizeof(char) * size), device_free};
 
     void* dbuffer = (void*)dbuffer_managed.get();
 
@@ -239,12 +239,12 @@ rocsparse_status testing_csrilusv(Arguments argus)
     std::vector<T> hz_gold(m);
 
     // Allocate device memory
-    auto dx_managed      = rocsparse_unique_ptr {device_malloc(sizeof(T) * m), device_free};
-    auto dy_1_managed    = rocsparse_unique_ptr {device_malloc(sizeof(T) * m), device_free};
-    auto dy_2_managed    = rocsparse_unique_ptr {device_malloc(sizeof(T) * m), device_free};
-    auto dz_1_managed    = rocsparse_unique_ptr {device_malloc(sizeof(T) * m), device_free};
-    auto dz_2_managed    = rocsparse_unique_ptr {device_malloc(sizeof(T) * m), device_free};
-    auto d_alpha_managed = rocsparse_unique_ptr {device_malloc(sizeof(T)), device_free};
+    auto dx_managed      = rocsparse_unique_ptr{device_malloc(sizeof(T) * m), device_free};
+    auto dy_1_managed    = rocsparse_unique_ptr{device_malloc(sizeof(T) * m), device_free};
+    auto dy_2_managed    = rocsparse_unique_ptr{device_malloc(sizeof(T) * m), device_free};
+    auto dz_1_managed    = rocsparse_unique_ptr{device_malloc(sizeof(T) * m), device_free};
+    auto dz_2_managed    = rocsparse_unique_ptr{device_malloc(sizeof(T) * m), device_free};
+    auto d_alpha_managed = rocsparse_unique_ptr{device_malloc(sizeof(T)), device_free};
 
     T* dx      = (T*)dx_managed.get();
     T* dy_1    = (T*)dy_1_managed.get();

--- a/clients/include/testing_csrmm.hpp
+++ b/clients/include/testing_csrmm.hpp
@@ -60,12 +60,12 @@ void testing_csrmm_bad_arg(void)
     rocsparse_mat_descr           descr = unique_ptr_descr->descr;
 
     auto dptr_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
     auto dcol_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
-    auto dval_managed = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
-    auto dB_managed   = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
-    auto dC_managed   = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+    auto dval_managed = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+    auto dB_managed   = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+    auto dC_managed   = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
 
     rocsparse_int* dptr = (rocsparse_int*)dptr_managed.get();
     rocsparse_int* dcol = (rocsparse_int*)dcol_managed.get();
@@ -340,13 +340,12 @@ rocsparse_status testing_csrmm(Arguments argus)
     if(M <= 0 || N <= 0 || K <= 0 || nnz <= 0)
     {
         auto dptr_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
         auto dcol_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
-        auto dval_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
-        auto dB_managed = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
-        auto dC_managed = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+        auto dval_managed = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+        auto dB_managed   = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+        auto dC_managed   = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
 
         rocsparse_int* dptr = (rocsparse_int*)dptr_managed.get();
         rocsparse_int* dcol = (rocsparse_int*)dcol_managed.get();
@@ -487,15 +486,15 @@ rocsparse_status testing_csrmm(Arguments argus)
 
     // allocate memory on device
     auto dcsr_row_ptrA_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * (M + 1)), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * (M + 1)), device_free};
     auto dcsr_col_indA_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * nnz), device_free};
-    auto dcsr_valA_managed = rocsparse_unique_ptr {device_malloc(sizeof(T) * nnz), device_free};
-    auto dB_managed        = rocsparse_unique_ptr {device_malloc(sizeof(T) * Bnnz), device_free};
-    auto dC_1_managed      = rocsparse_unique_ptr {device_malloc(sizeof(T) * Cnnz), device_free};
-    auto dC_2_managed      = rocsparse_unique_ptr {device_malloc(sizeof(T) * Cnnz), device_free};
-    auto d_alpha_managed   = rocsparse_unique_ptr {device_malloc(sizeof(T)), device_free};
-    auto d_beta_managed    = rocsparse_unique_ptr {device_malloc(sizeof(T)), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * nnz), device_free};
+    auto dcsr_valA_managed = rocsparse_unique_ptr{device_malloc(sizeof(T) * nnz), device_free};
+    auto dB_managed        = rocsparse_unique_ptr{device_malloc(sizeof(T) * Bnnz), device_free};
+    auto dC_1_managed      = rocsparse_unique_ptr{device_malloc(sizeof(T) * Cnnz), device_free};
+    auto dC_2_managed      = rocsparse_unique_ptr{device_malloc(sizeof(T) * Cnnz), device_free};
+    auto d_alpha_managed   = rocsparse_unique_ptr{device_malloc(sizeof(T)), device_free};
+    auto d_beta_managed    = rocsparse_unique_ptr{device_malloc(sizeof(T)), device_free};
 
     rocsparse_int* dcsr_row_ptrA = (rocsparse_int*)dcsr_row_ptrA_managed.get();
     rocsparse_int* dcsr_col_indA = (rocsparse_int*)dcsr_col_indA_managed.get();

--- a/clients/include/testing_csrmv.hpp
+++ b/clients/include/testing_csrmv.hpp
@@ -59,12 +59,12 @@ void testing_csrmv_bad_arg(void)
     rocsparse_mat_info               info = unique_ptr_mat_info->info;
 
     auto dptr_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
     auto dcol_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
-    auto dval_managed = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
-    auto dx_managed   = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
-    auto dy_managed   = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+    auto dval_managed = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+    auto dx_managed   = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+    auto dy_managed   = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
 
     rocsparse_int* dptr = (rocsparse_int*)dptr_managed.get();
     rocsparse_int* dcol = (rocsparse_int*)dcol_managed.get();
@@ -404,13 +404,12 @@ rocsparse_status testing_csrmv(Arguments argus)
     if(m <= 0 || n <= 0 || nnz <= 0)
     {
         auto dptr_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
         auto dcol_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
-        auto dval_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
-        auto dx_managed = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
-        auto dy_managed = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+        auto dval_managed = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+        auto dx_managed   = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+        auto dy_managed   = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
 
         rocsparse_int* dptr = (rocsparse_int*)dptr_managed.get();
         rocsparse_int* dcol = (rocsparse_int*)dcol_managed.get();
@@ -540,15 +539,15 @@ rocsparse_status testing_csrmv(Arguments argus)
 
     // allocate memory on device
     auto dptr_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * (m + 1)), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * (m + 1)), device_free};
     auto dcol_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * nnz), device_free};
-    auto dval_managed    = rocsparse_unique_ptr {device_malloc(sizeof(T) * nnz), device_free};
-    auto dx_managed      = rocsparse_unique_ptr {device_malloc(sizeof(T) * n), device_free};
-    auto dy_1_managed    = rocsparse_unique_ptr {device_malloc(sizeof(T) * m), device_free};
-    auto dy_2_managed    = rocsparse_unique_ptr {device_malloc(sizeof(T) * m), device_free};
-    auto d_alpha_managed = rocsparse_unique_ptr {device_malloc(sizeof(T)), device_free};
-    auto d_beta_managed  = rocsparse_unique_ptr {device_malloc(sizeof(T)), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * nnz), device_free};
+    auto dval_managed    = rocsparse_unique_ptr{device_malloc(sizeof(T) * nnz), device_free};
+    auto dx_managed      = rocsparse_unique_ptr{device_malloc(sizeof(T) * n), device_free};
+    auto dy_1_managed    = rocsparse_unique_ptr{device_malloc(sizeof(T) * m), device_free};
+    auto dy_2_managed    = rocsparse_unique_ptr{device_malloc(sizeof(T) * m), device_free};
+    auto d_alpha_managed = rocsparse_unique_ptr{device_malloc(sizeof(T)), device_free};
+    auto d_beta_managed  = rocsparse_unique_ptr{device_malloc(sizeof(T)), device_free};
 
     rocsparse_int* dptr    = (rocsparse_int*)dptr_managed.get();
     rocsparse_int* dcol    = (rocsparse_int*)dcol_managed.get();

--- a/clients/include/testing_csrsort.hpp
+++ b/clients/include/testing_csrsort.hpp
@@ -54,13 +54,13 @@ void testing_csrsort_bad_arg(void)
     size_t buffer_size = 0;
 
     auto csr_row_ptr_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
     auto csr_col_ind_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
     auto perm_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
     auto buffer_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(char) * safe_size), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(char) * safe_size), device_free};
 
     rocsparse_int* csr_row_ptr = (rocsparse_int*)csr_row_ptr_managed.get();
     rocsparse_int* csr_col_ind = (rocsparse_int*)csr_col_ind_managed.get();
@@ -205,13 +205,13 @@ rocsparse_status testing_csrsort(Arguments argus)
     if(m <= 0 || n <= 0 || nnz <= 0)
     {
         auto csr_row_ptr_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
         auto csr_col_ind_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
         auto perm_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
         auto buffer_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(char) * safe_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(char) * safe_size), device_free};
 
         rocsparse_int* csr_row_ptr = (rocsparse_int*)csr_row_ptr_managed.get();
         rocsparse_int* csr_col_ind = (rocsparse_int*)csr_col_ind_managed.get();
@@ -343,14 +343,14 @@ rocsparse_status testing_csrsort(Arguments argus)
 
     // Allocate memory on the device
     auto dcsr_row_ptr_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * (m + 1)), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * (m + 1)), device_free};
     auto dcsr_col_ind_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * nnz), device_free};
-    auto dcsr_val_managed = rocsparse_unique_ptr {device_malloc(sizeof(float) * nnz), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * nnz), device_free};
+    auto dcsr_val_managed = rocsparse_unique_ptr{device_malloc(sizeof(float) * nnz), device_free};
     auto dcsr_val_sorted_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(float) * nnz), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(float) * nnz), device_free};
     auto dperm_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * nnz), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * nnz), device_free};
 
     rocsparse_int* dcsr_row_ptr    = (rocsparse_int*)dcsr_row_ptr_managed.get();
     rocsparse_int* dcsr_col_ind    = (rocsparse_int*)dcsr_col_ind_managed.get();
@@ -386,7 +386,7 @@ rocsparse_status testing_csrsort(Arguments argus)
 
         // Allocate buffer on the device
         auto dbuffer_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(char) * buffer_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(char) * buffer_size), device_free};
 
         void* dbuffer = (void*)dbuffer_managed.get();
 
@@ -445,7 +445,7 @@ rocsparse_status testing_csrsort(Arguments argus)
         rocsparse_csrsort_buffer_size(handle, m, n, nnz, dcsr_row_ptr, dcsr_col_ind, &buffer_size);
 
         auto dbuffer_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(char) * buffer_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(char) * buffer_size), device_free};
         void* dbuffer = (void*)dbuffer_managed.get();
 
         for(rocsparse_int iter = 0; iter < number_cold_calls; ++iter)

--- a/clients/include/testing_csrsv.hpp
+++ b/clients/include/testing_csrsv.hpp
@@ -61,14 +61,14 @@ void testing_csrsv_bad_arg(void)
     rocsparse_mat_info               info = unique_ptr_mat_info->info;
 
     auto dptr_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
     auto dcol_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
-    auto dval_managed = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
-    auto dx_managed   = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
-    auto dy_managed   = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+    auto dval_managed = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+    auto dx_managed   = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+    auto dy_managed   = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
     auto dbuffer_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(char) * safe_size), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(char) * safe_size), device_free};
 
     rocsparse_int* dptr    = (rocsparse_int*)dptr_managed.get();
     rocsparse_int* dcol    = (rocsparse_int*)dcol_managed.get();
@@ -522,15 +522,14 @@ rocsparse_status testing_csrsv(Arguments argus)
     if(m <= 0 || nnz <= 0)
     {
         auto dptr_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
         auto dcol_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
-        auto dval_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
-        auto dx_managed = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
-        auto dy_managed = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+        auto dval_managed = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+        auto dx_managed   = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+        auto dy_managed   = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
         auto buffer_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(char) * safe_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(char) * safe_size), device_free};
 
         rocsparse_int* dptr   = (rocsparse_int*)dptr_managed.get();
         rocsparse_int* dcol   = (rocsparse_int*)dcol_managed.get();
@@ -696,16 +695,16 @@ rocsparse_status testing_csrsv(Arguments argus)
 
     // Allocate memory on device
     auto dptr_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * (m + 1)), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * (m + 1)), device_free};
     auto dcol_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * nnz), device_free};
-    auto dval_managed    = rocsparse_unique_ptr {device_malloc(sizeof(T) * nnz), device_free};
-    auto dx_managed      = rocsparse_unique_ptr {device_malloc(sizeof(T) * m), device_free};
-    auto dy_1_managed    = rocsparse_unique_ptr {device_malloc(sizeof(T) * n), device_free};
-    auto dy_2_managed    = rocsparse_unique_ptr {device_malloc(sizeof(T) * n), device_free};
-    auto d_alpha_managed = rocsparse_unique_ptr {device_malloc(sizeof(T)), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * nnz), device_free};
+    auto dval_managed    = rocsparse_unique_ptr{device_malloc(sizeof(T) * nnz), device_free};
+    auto dx_managed      = rocsparse_unique_ptr{device_malloc(sizeof(T) * m), device_free};
+    auto dy_1_managed    = rocsparse_unique_ptr{device_malloc(sizeof(T) * n), device_free};
+    auto dy_2_managed    = rocsparse_unique_ptr{device_malloc(sizeof(T) * n), device_free};
+    auto d_alpha_managed = rocsparse_unique_ptr{device_malloc(sizeof(T)), device_free};
     auto d_position_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int)), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int)), device_free};
 
     rocsparse_int* dptr       = (rocsparse_int*)dptr_managed.get();
     rocsparse_int* dcol       = (rocsparse_int*)dcol_managed.get();
@@ -739,7 +738,7 @@ rocsparse_status testing_csrsv(Arguments argus)
         rocsparse_csrsv_buffer_size(handle, trans, m, nnz, descr, dval, dptr, dcol, info, &size));
 
     // Allocate buffer on the device
-    auto dbuffer_managed = rocsparse_unique_ptr {device_malloc(sizeof(char) * size), device_free};
+    auto dbuffer_managed = rocsparse_unique_ptr{device_malloc(sizeof(char) * size), device_free};
 
     void* dbuffer = (void*)dbuffer_managed.get();
 

--- a/clients/include/testing_doti.hpp
+++ b/clients/include/testing_doti.hpp
@@ -47,10 +47,10 @@ void testing_doti_bad_arg(void)
     std::unique_ptr<handle_struct> unique_ptr_handle(new handle_struct);
     rocsparse_handle               handle = unique_ptr_handle->handle;
 
-    auto dx_val_managed = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+    auto dx_val_managed = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
     auto dx_ind_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
-    auto dy_managed = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+    auto dy_managed = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
 
     T*             dx_val = (T*)dx_val_managed.get();
     rocsparse_int* dx_ind = (rocsparse_int*)dx_ind_managed.get();
@@ -121,10 +121,10 @@ rocsparse_status testing_doti(Arguments argus)
     if(nnz <= 0)
     {
         auto dx_ind_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
         auto dx_val_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
-        auto dy_managed = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+        auto dy_managed = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
 
         rocsparse_int* dx_ind = (rocsparse_int*)dx_ind_managed.get();
         T*             dx_val = (T*)dx_val_managed.get();
@@ -171,10 +171,10 @@ rocsparse_status testing_doti(Arguments argus)
 
     // allocate memory on device
     auto dx_ind_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * nnz), device_free};
-    auto dx_val_managed    = rocsparse_unique_ptr {device_malloc(sizeof(T) * nnz), device_free};
-    auto dy_managed        = rocsparse_unique_ptr {device_malloc(sizeof(T) * N), device_free};
-    auto dresult_2_managed = rocsparse_unique_ptr {device_malloc(sizeof(T)), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * nnz), device_free};
+    auto dx_val_managed    = rocsparse_unique_ptr{device_malloc(sizeof(T) * nnz), device_free};
+    auto dy_managed        = rocsparse_unique_ptr{device_malloc(sizeof(T) * N), device_free};
+    auto dresult_2_managed = rocsparse_unique_ptr{device_malloc(sizeof(T)), device_free};
 
     rocsparse_int* dx_ind    = (rocsparse_int*)dx_ind_managed.get();
     T*             dx_val    = (T*)dx_val_managed.get();

--- a/clients/include/testing_ell2csr.hpp
+++ b/clients/include/testing_ell2csr.hpp
@@ -60,9 +60,9 @@ void testing_ell2csr_bad_arg(void)
     rocsparse_mat_descr           ell_descr = unique_ptr_ell_descr->descr;
 
     auto ell_col_ind_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
     auto csr_row_ptr_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
 
     rocsparse_int* ell_col_ind = (rocsparse_int*)ell_col_ind_managed.get();
     rocsparse_int* csr_row_ptr = (rocsparse_int*)csr_row_ptr_managed.get();
@@ -133,10 +133,10 @@ void testing_ell2csr_bad_arg(void)
     }
 
     // Allocate memory for ELL storage format
-    auto ell_val_managed = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+    auto ell_val_managed = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
     auto csr_col_ind_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
-    auto csr_val_managed = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+    auto csr_val_managed = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
 
     T*             ell_val     = (T*)ell_val_managed.get();
     rocsparse_int* csr_col_ind = (rocsparse_int*)csr_col_ind_managed.get();
@@ -349,11 +349,11 @@ rocsparse_status testing_ell2csr(Arguments argus)
     if(m <= 0 || n <= 0 || nnz <= 0)
     {
         auto ell_col_ind_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
         auto ell_val_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
         auto csr_row_ptr_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
 
         rocsparse_int* ell_col_ind = (rocsparse_int*)ell_col_ind_managed.get();
         T*             ell_val     = (T*)ell_val_managed.get();
@@ -384,9 +384,9 @@ rocsparse_status testing_ell2csr(Arguments argus)
 
         // Step 2 - perform actual conversion
         auto csr_col_ind_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
         auto csr_val_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
 
         rocsparse_int* csr_col_ind = (rocsparse_int*)csr_col_ind_managed.get();
         T*             csr_val     = (T*)csr_val_managed.get();
@@ -496,10 +496,10 @@ rocsparse_status testing_ell2csr(Arguments argus)
 
     // Allocate memory on the device
     auto dcsr_row_ptr_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * (m + 1)), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * (m + 1)), device_free};
     auto dcsr_col_ind_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * nnz), device_free};
-    auto dcsr_val_managed = rocsparse_unique_ptr {device_malloc(sizeof(T) * nnz), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * nnz), device_free};
+    auto dcsr_val_managed = rocsparse_unique_ptr{device_malloc(sizeof(T) * nnz), device_free};
 
     rocsparse_int* dcsr_row_ptr = (rocsparse_int*)dcsr_row_ptr_managed.get();
     rocsparse_int* dcsr_col_ind = (rocsparse_int*)dcsr_col_ind_managed.get();
@@ -530,10 +530,10 @@ rocsparse_status testing_ell2csr(Arguments argus)
     CHECK_ROCSPARSE_ERROR(
         rocsparse_csr2ell_width(handle, m, csr_descr, dcsr_row_ptr, ell_descr, &ell_width));
 
-    auto dell_col_ind_managed = rocsparse_unique_ptr {
-        device_malloc(sizeof(rocsparse_int) * (ell_width * m)), device_free};
+    auto dell_col_ind_managed
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * (ell_width * m)), device_free};
     auto dell_val_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(T) * (ell_width * m)), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(T) * (ell_width * m)), device_free};
 
     rocsparse_int* dell_col_ind = (rocsparse_int*)dell_col_ind_managed.get();
     T*             dell_val     = (T*)dell_val_managed.get();
@@ -562,7 +562,7 @@ rocsparse_status testing_ell2csr(Arguments argus)
         rocsparse_int csr_nnz;
 
         auto dcsr_row_ptr_conv_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * (m + 1)), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * (m + 1)), device_free};
 
         rocsparse_int* dcsr_row_ptr_conv = (rocsparse_int*)dcsr_row_ptr_conv_managed.get();
 
@@ -587,9 +587,9 @@ rocsparse_status testing_ell2csr(Arguments argus)
 
         // Allocate CSR column and values arrays
         auto dcsr_col_ind_conv_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * csr_nnz), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * csr_nnz), device_free};
         auto dcsr_val_conv_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(T) * csr_nnz), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(T) * csr_nnz), device_free};
 
         rocsparse_int* dcsr_col_ind_conv = (rocsparse_int*)dcsr_col_ind_conv_managed.get();
         T*             dcsr_val_conv     = (T*)dcsr_val_conv_managed.get();
@@ -643,8 +643,8 @@ rocsparse_status testing_ell2csr(Arguments argus)
 
         for(rocsparse_int iter = 0; iter < number_cold_calls; ++iter)
         {
-            auto dcsr_row_ptr_conv_managed = rocsparse_unique_ptr {
-                device_malloc(sizeof(rocsparse_int) * (m + 1)), device_free};
+            auto dcsr_row_ptr_conv_managed
+                = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * (m + 1)), device_free};
 
             rocsparse_int* dcsr_row_ptr_conv = (rocsparse_int*)dcsr_row_ptr_conv_managed.get();
 
@@ -659,10 +659,10 @@ rocsparse_status testing_ell2csr(Arguments argus)
                                   dcsr_row_ptr_conv,
                                   &csr_nnz);
 
-            auto dcsr_col_ind_conv_managed = rocsparse_unique_ptr {
-                device_malloc(sizeof(rocsparse_int) * csr_nnz), device_free};
+            auto dcsr_col_ind_conv_managed
+                = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * csr_nnz), device_free};
             auto dcsr_val_conv_managed
-                = rocsparse_unique_ptr {device_malloc(sizeof(T) * csr_nnz), device_free};
+                = rocsparse_unique_ptr{device_malloc(sizeof(T) * csr_nnz), device_free};
 
             rocsparse_int* dcsr_col_ind_conv = (rocsparse_int*)dcsr_col_ind_conv_managed.get();
             T*             dcsr_val_conv     = (T*)dcsr_val_conv_managed.get();
@@ -684,8 +684,8 @@ rocsparse_status testing_ell2csr(Arguments argus)
 
         for(rocsparse_int iter = 0; iter < number_hot_calls; ++iter)
         {
-            auto dcsr_row_ptr_conv_managed = rocsparse_unique_ptr {
-                device_malloc(sizeof(rocsparse_int) * (m + 1)), device_free};
+            auto dcsr_row_ptr_conv_managed
+                = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * (m + 1)), device_free};
 
             rocsparse_int* dcsr_row_ptr_conv = (rocsparse_int*)dcsr_row_ptr_conv_managed.get();
 
@@ -700,10 +700,10 @@ rocsparse_status testing_ell2csr(Arguments argus)
                                   dcsr_row_ptr_conv,
                                   &csr_nnz);
 
-            auto dcsr_col_ind_conv_managed = rocsparse_unique_ptr {
-                device_malloc(sizeof(rocsparse_int) * csr_nnz), device_free};
+            auto dcsr_col_ind_conv_managed
+                = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * csr_nnz), device_free};
             auto dcsr_val_conv_managed
-                = rocsparse_unique_ptr {device_malloc(sizeof(T) * csr_nnz), device_free};
+                = rocsparse_unique_ptr{device_malloc(sizeof(T) * csr_nnz), device_free};
 
             rocsparse_int* dcsr_col_ind_conv = (rocsparse_int*)dcsr_col_ind_conv_managed.get();
             T*             dcsr_val_conv     = (T*)dcsr_val_conv_managed.get();

--- a/clients/include/testing_ellmv.hpp
+++ b/clients/include/testing_ellmv.hpp
@@ -59,10 +59,10 @@ void testing_ellmv_bad_arg(void)
     rocsparse_mat_descr           descr = unique_ptr_descr->descr;
 
     auto dcol_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
-    auto dval_managed = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
-    auto dx_managed   = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
-    auto dy_managed   = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+    auto dval_managed = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+    auto dx_managed   = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+    auto dy_managed   = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
 
     rocsparse_int* dcol = (rocsparse_int*)dcol_managed.get();
     T*             dval = (T*)dval_managed.get();
@@ -189,11 +189,10 @@ rocsparse_status testing_ellmv(Arguments argus)
     if(m <= 0 || n <= 0 || nnz <= 0)
     {
         auto dcol_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
-        auto dval_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
-        auto dx_managed = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
-        auto dy_managed = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+        auto dval_managed = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+        auto dx_managed   = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+        auto dy_managed   = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
 
         rocsparse_int* dcol = (rocsparse_int*)dcol_managed.get();
         T*             dval = (T*)dval_managed.get();
@@ -323,13 +322,13 @@ rocsparse_status testing_ellmv(Arguments argus)
 
     // allocate memory on device
     auto dcol_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * ell_nnz), device_free};
-    auto dval_managed    = rocsparse_unique_ptr {device_malloc(sizeof(T) * ell_nnz), device_free};
-    auto dx_managed      = rocsparse_unique_ptr {device_malloc(sizeof(T) * n), device_free};
-    auto dy_1_managed    = rocsparse_unique_ptr {device_malloc(sizeof(T) * m), device_free};
-    auto dy_2_managed    = rocsparse_unique_ptr {device_malloc(sizeof(T) * m), device_free};
-    auto d_alpha_managed = rocsparse_unique_ptr {device_malloc(sizeof(T)), device_free};
-    auto d_beta_managed  = rocsparse_unique_ptr {device_malloc(sizeof(T)), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * ell_nnz), device_free};
+    auto dval_managed    = rocsparse_unique_ptr{device_malloc(sizeof(T) * ell_nnz), device_free};
+    auto dx_managed      = rocsparse_unique_ptr{device_malloc(sizeof(T) * n), device_free};
+    auto dy_1_managed    = rocsparse_unique_ptr{device_malloc(sizeof(T) * m), device_free};
+    auto dy_2_managed    = rocsparse_unique_ptr{device_malloc(sizeof(T) * m), device_free};
+    auto d_alpha_managed = rocsparse_unique_ptr{device_malloc(sizeof(T)), device_free};
+    auto d_beta_managed  = rocsparse_unique_ptr{device_malloc(sizeof(T)), device_free};
 
     rocsparse_int* dcol    = (rocsparse_int*)dcol_managed.get();
     T*             dval    = (T*)dval_managed.get();

--- a/clients/include/testing_gthr.hpp
+++ b/clients/include/testing_gthr.hpp
@@ -47,10 +47,10 @@ void testing_gthr_bad_arg(void)
     std::unique_ptr<handle_struct> unique_ptr_handle(new handle_struct);
     rocsparse_handle               handle = unique_ptr_handle->handle;
 
-    auto dx_val_managed = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+    auto dx_val_managed = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
     auto dx_ind_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
-    auto dy_managed = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+    auto dy_managed = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
 
     T*             dx_val = (T*)dx_val_managed.get();
     rocsparse_int* dx_ind = (rocsparse_int*)dx_ind_managed.get();
@@ -108,10 +108,10 @@ rocsparse_status testing_gthr(Arguments argus)
     if(nnz <= 0)
     {
         auto dx_ind_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
         auto dx_val_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
-        auto dy_managed = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+        auto dy_managed = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
 
         rocsparse_int* dx_ind = (rocsparse_int*)dx_ind_managed.get();
         T*             dx_val = (T*)dx_val_managed.get();
@@ -152,9 +152,9 @@ rocsparse_status testing_gthr(Arguments argus)
 
     // allocate memory on device
     auto dx_ind_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * nnz), device_free};
-    auto dx_val_managed = rocsparse_unique_ptr {device_malloc(sizeof(T) * nnz), device_free};
-    auto dy_managed     = rocsparse_unique_ptr {device_malloc(sizeof(T) * N), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * nnz), device_free};
+    auto dx_val_managed = rocsparse_unique_ptr{device_malloc(sizeof(T) * nnz), device_free};
+    auto dy_managed     = rocsparse_unique_ptr{device_malloc(sizeof(T) * N), device_free};
 
     rocsparse_int* dx_ind = (rocsparse_int*)dx_ind_managed.get();
     T*             dx_val = (T*)dx_val_managed.get();

--- a/clients/include/testing_gthrz.hpp
+++ b/clients/include/testing_gthrz.hpp
@@ -47,10 +47,10 @@ void testing_gthrz_bad_arg(void)
     std::unique_ptr<handle_struct> unique_ptr_handle(new handle_struct);
     rocsparse_handle               handle = unique_ptr_handle->handle;
 
-    auto dx_val_managed = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+    auto dx_val_managed = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
     auto dx_ind_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
-    auto dy_managed = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+    auto dy_managed = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
 
     T*             dx_val = (T*)dx_val_managed.get();
     rocsparse_int* dx_ind = (rocsparse_int*)dx_ind_managed.get();
@@ -108,10 +108,10 @@ rocsparse_status testing_gthrz(Arguments argus)
     if(nnz <= 0)
     {
         auto dx_ind_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
         auto dx_val_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
-        auto dy_managed = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+        auto dy_managed = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
 
         rocsparse_int* dx_ind = (rocsparse_int*)dx_ind_managed.get();
         T*             dx_val = (T*)dx_val_managed.get();
@@ -155,9 +155,9 @@ rocsparse_status testing_gthrz(Arguments argus)
 
     // allocate memory on device
     auto dx_ind_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * nnz), device_free};
-    auto dx_val_managed = rocsparse_unique_ptr {device_malloc(sizeof(T) * nnz), device_free};
-    auto dy_managed     = rocsparse_unique_ptr {device_malloc(sizeof(T) * N), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * nnz), device_free};
+    auto dx_val_managed = rocsparse_unique_ptr{device_malloc(sizeof(T) * nnz), device_free};
+    auto dy_managed     = rocsparse_unique_ptr{device_malloc(sizeof(T) * N), device_free};
 
     rocsparse_int* dx_ind = (rocsparse_int*)dx_ind_managed.get();
     T*             dx_val = (T*)dx_val_managed.get();

--- a/clients/include/testing_hybmv.hpp
+++ b/clients/include/testing_hybmv.hpp
@@ -73,8 +73,8 @@ void testing_hybmv_bad_arg(void)
     std::unique_ptr<hyb_struct> unique_ptr_hyb(new hyb_struct);
     rocsparse_hyb_mat           hyb = unique_ptr_hyb->hyb;
 
-    auto dx_managed = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
-    auto dy_managed = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+    auto dx_managed = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+    auto dy_managed = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
 
     T* dx = (T*)dx_managed.get();
     T* dy = (T*)dy_managed.get();
@@ -189,13 +189,12 @@ rocsparse_status testing_hybmv(Arguments argus)
     if(m <= 0 || n <= 0 || nnz <= 0)
     {
         auto dptr_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
         auto dcol_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
-        auto dval_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
-        auto dx_managed = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
-        auto dy_managed = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+        auto dval_managed = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+        auto dx_managed   = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+        auto dy_managed   = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
 
         rocsparse_int* dptr = (rocsparse_int*)dptr_managed.get();
         rocsparse_int* dcol = (rocsparse_int*)dcol_managed.get();
@@ -292,15 +291,15 @@ rocsparse_status testing_hybmv(Arguments argus)
 
     // allocate memory on device
     auto dptr_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * (m + 1)), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * (m + 1)), device_free};
     auto dcol_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * nnz), device_free};
-    auto dval_managed    = rocsparse_unique_ptr {device_malloc(sizeof(T) * nnz), device_free};
-    auto dx_managed      = rocsparse_unique_ptr {device_malloc(sizeof(T) * n), device_free};
-    auto dy_1_managed    = rocsparse_unique_ptr {device_malloc(sizeof(T) * m), device_free};
-    auto dy_2_managed    = rocsparse_unique_ptr {device_malloc(sizeof(T) * m), device_free};
-    auto d_alpha_managed = rocsparse_unique_ptr {device_malloc(sizeof(T)), device_free};
-    auto d_beta_managed  = rocsparse_unique_ptr {device_malloc(sizeof(T)), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * nnz), device_free};
+    auto dval_managed    = rocsparse_unique_ptr{device_malloc(sizeof(T) * nnz), device_free};
+    auto dx_managed      = rocsparse_unique_ptr{device_malloc(sizeof(T) * n), device_free};
+    auto dy_1_managed    = rocsparse_unique_ptr{device_malloc(sizeof(T) * m), device_free};
+    auto dy_2_managed    = rocsparse_unique_ptr{device_malloc(sizeof(T) * m), device_free};
+    auto d_alpha_managed = rocsparse_unique_ptr{device_malloc(sizeof(T)), device_free};
+    auto d_beta_managed  = rocsparse_unique_ptr{device_malloc(sizeof(T)), device_free};
 
     rocsparse_int* dptr    = (rocsparse_int*)dptr_managed.get();
     rocsparse_int* dcol    = (rocsparse_int*)dcol_managed.get();

--- a/clients/include/testing_identity.hpp
+++ b/clients/include/testing_identity.hpp
@@ -46,7 +46,7 @@ void testing_identity_bad_arg(void)
     rocsparse_handle               handle = unique_ptr_handle->handle;
 
     auto p_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
 
     rocsparse_int* p = (rocsparse_int*)p_managed.get();
 
@@ -86,7 +86,7 @@ rocsparse_status testing_identity(Arguments argus)
     if(n <= 0)
     {
         auto p_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
 
         rocsparse_int* p = (rocsparse_int*)p_managed.get();
 
@@ -121,7 +121,7 @@ rocsparse_status testing_identity(Arguments argus)
     }
 
     // Allocate memory on the device
-    auto dp_managed = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * n), device_free};
+    auto dp_managed = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * n), device_free};
 
     rocsparse_int* dp = (rocsparse_int*)dp_managed.get();
 

--- a/clients/include/testing_roti.hpp
+++ b/clients/include/testing_roti.hpp
@@ -49,10 +49,10 @@ void testing_roti_bad_arg(void)
     std::unique_ptr<handle_struct> unique_ptr_handle(new handle_struct);
     rocsparse_handle               handle = unique_ptr_handle->handle;
 
-    auto dx_val_managed = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+    auto dx_val_managed = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
     auto dx_ind_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
-    auto dy_managed = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+    auto dy_managed = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
 
     T*             dx_val = (T*)dx_val_managed.get();
     rocsparse_int* dx_ind = (rocsparse_int*)dx_ind_managed.get();
@@ -126,10 +126,10 @@ rocsparse_status testing_roti(Arguments argus)
     if(nnz <= 0)
     {
         auto dx_ind_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
         auto dx_val_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
-        auto dy_managed = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+        auto dy_managed = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
 
         rocsparse_int* dx_ind = (rocsparse_int*)dx_ind_managed.get();
         T*             dx_val = (T*)dx_val_managed.get();
@@ -179,13 +179,13 @@ rocsparse_status testing_roti(Arguments argus)
 
     // allocate memory on device
     auto dx_ind_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * nnz), device_free};
-    auto dx_val_1_managed = rocsparse_unique_ptr {device_malloc(sizeof(T) * nnz), device_free};
-    auto dx_val_2_managed = rocsparse_unique_ptr {device_malloc(sizeof(T) * nnz), device_free};
-    auto dy_1_managed     = rocsparse_unique_ptr {device_malloc(sizeof(T) * N), device_free};
-    auto dy_2_managed     = rocsparse_unique_ptr {device_malloc(sizeof(T) * N), device_free};
-    auto dc_managed       = rocsparse_unique_ptr {device_malloc(sizeof(T)), device_free};
-    auto ds_managed       = rocsparse_unique_ptr {device_malloc(sizeof(T)), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * nnz), device_free};
+    auto dx_val_1_managed = rocsparse_unique_ptr{device_malloc(sizeof(T) * nnz), device_free};
+    auto dx_val_2_managed = rocsparse_unique_ptr{device_malloc(sizeof(T) * nnz), device_free};
+    auto dy_1_managed     = rocsparse_unique_ptr{device_malloc(sizeof(T) * N), device_free};
+    auto dy_2_managed     = rocsparse_unique_ptr{device_malloc(sizeof(T) * N), device_free};
+    auto dc_managed       = rocsparse_unique_ptr{device_malloc(sizeof(T)), device_free};
+    auto ds_managed       = rocsparse_unique_ptr{device_malloc(sizeof(T)), device_free};
 
     rocsparse_int* dx_ind   = (rocsparse_int*)dx_ind_managed.get();
     T*             dx_val_1 = (T*)dx_val_1_managed.get();

--- a/clients/include/testing_sctr.hpp
+++ b/clients/include/testing_sctr.hpp
@@ -47,10 +47,10 @@ void testing_sctr_bad_arg(void)
     std::unique_ptr<handle_struct> unique_ptr_handle(new handle_struct);
     rocsparse_handle               handle = unique_ptr_handle->handle;
 
-    auto dx_val_managed = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+    auto dx_val_managed = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
     auto dx_ind_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
-    auto dy_managed = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+    auto dy_managed = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
 
     T*             dx_val = (T*)dx_val_managed.get();
     rocsparse_int* dx_ind = (rocsparse_int*)dx_ind_managed.get();
@@ -108,10 +108,10 @@ rocsparse_status testing_sctr(Arguments argus)
     if(nnz <= 0)
     {
         auto dx_ind_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * safe_size), device_free};
         auto dx_val_managed
-            = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
-        auto dy_managed = rocsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+            = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+        auto dy_managed = rocsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
 
         rocsparse_int* dx_ind = (rocsparse_int*)dx_ind_managed.get();
         T*             dx_val = (T*)dx_val_managed.get();
@@ -155,9 +155,9 @@ rocsparse_status testing_sctr(Arguments argus)
 
     // allocate memory on device
     auto dx_ind_managed
-        = rocsparse_unique_ptr {device_malloc(sizeof(rocsparse_int) * nnz), device_free};
-    auto dx_val_managed = rocsparse_unique_ptr {device_malloc(sizeof(T) * nnz), device_free};
-    auto dy_managed     = rocsparse_unique_ptr {device_malloc(sizeof(T) * N), device_free};
+        = rocsparse_unique_ptr{device_malloc(sizeof(rocsparse_int) * nnz), device_free};
+    auto dx_val_managed = rocsparse_unique_ptr{device_malloc(sizeof(T) * nnz), device_free};
+    auto dy_managed     = rocsparse_unique_ptr{device_malloc(sizeof(T) * N), device_free};
 
     rocsparse_int* dx_ind = (rocsparse_int*)dx_ind_managed.get();
     T*             dx_val = (T*)dx_val_managed.get();

--- a/library/src/handle.cpp
+++ b/library/src/handle.cpp
@@ -27,7 +27,7 @@
 
 #include <hip/hip_runtime.h>
 
-__global__ void init_kernel() {};
+__global__ void init_kernel(){};
 
 /*******************************************************************************
  * constructor

--- a/library/src/include/logging.h
+++ b/library/src/include/logging.h
@@ -100,7 +100,7 @@ inline void open_log_stream(std::ostream** log_os,
 template <typename F, typename... Ts>
 void each_args(F f, Ts&... xs)
 {
-    (void)std::initializer_list<int> {((void)f(xs), 0)...};
+    (void)std::initializer_list<int>{((void)f(xs), 0)...};
 }
 
 /**
@@ -182,7 +182,7 @@ template <typename H, typename... Ts>
 void log_arguments(std::ostream& os, std::string& separator, H head, Ts&... xs)
 {
     os << "\n" << head;
-    each_args(log_arg {os, separator}, xs...);
+    each_args(log_arg{os, separator}, xs...);
 }
 
 /**

--- a/library/src/level2/coomv_device.h
+++ b/library/src/level2/coomv_device.h
@@ -79,7 +79,7 @@ static __device__ void coomvn_general_wf_reduce(rocsparse_int        nnz,
 
     // Shared memory to hold row indices and values for segmented reduction
     __shared__ rocsparse_int shared_row[BLOCKSIZE];
-    __shared__ T shared_val[BLOCKSIZE];
+    __shared__ T             shared_val[BLOCKSIZE];
 
     // Initialize shared memory
     shared_row[tid] = -1;
@@ -222,7 +222,7 @@ __global__ void coomvn_general_block_reduce(rocsparse_int nnz,
 
     // Shared memory to hold row indices and values for segmented reduction
     __shared__ rocsparse_int shared_row[BLOCKSIZE];
-    __shared__ T shared_val[BLOCKSIZE];
+    __shared__ T             shared_val[BLOCKSIZE];
 
     // Loop over blocks that are subject for segmented reduction
     for(rocsparse_int i = tid; i < nnz; i += BLOCKSIZE)

--- a/library/src/level3/csrmm_device.h
+++ b/library/src/level3/csrmm_device.h
@@ -56,7 +56,7 @@ static __device__ void csrmmnn_general_device(rocsparse_int M,
     rocsparse_int colC = col * ldc;
 
     __shared__ rocsparse_int shared_col[BLOCKSIZE / WF_SIZE][WF_SIZE];
-    __shared__ T shared_val[BLOCKSIZE / WF_SIZE][WF_SIZE];
+    __shared__ T             shared_val[BLOCKSIZE / WF_SIZE][WF_SIZE];
 
     for(rocsparse_int row = gid / WF_SIZE; row < M; row += nwf)
     {
@@ -126,7 +126,7 @@ static __device__ void csrmmnt_general_device(rocsparse_int offset,
     }
 
     __shared__ rocsparse_int shared_col[BLOCKSIZE / WF_SIZE][WF_SIZE];
-    __shared__ T shared_val[BLOCKSIZE / WF_SIZE][WF_SIZE];
+    __shared__ T             shared_val[BLOCKSIZE / WF_SIZE][WF_SIZE];
 
     rocsparse_int row_start = csr_row_ptr[row] - idx_base;
     rocsparse_int row_end   = csr_row_ptr[row + 1] - idx_base;


### PR DESCRIPTION
- Additional options are now available in clang-format, and they need to be applied to Jenkins after I upgraded CI from rocm2.4 to rocm2.5

