### PR TITLE
Added hip-clang support

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ import com.amd.docker.*
 // Mostly generated from snippet generator 'properties; set job properties'
 // Time-based triggers added to execute nightly tests, eg '30 2 * * *' means 2:30 AM
 properties([
-    pipelineTriggers([cron('0 22 * * *'), [$class: 'PeriodicFolderTrigger', interval: '5m']]),
+    pipelineTriggers([cron('0 23 * * *'), [$class: 'PeriodicFolderTrigger', interval: '5m']]),
     buildDiscarder(logRotator(
       artifactDaysToKeepStr: '',
       artifactNumToKeepStr: '',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ import com.amd.docker.*
 // Mostly generated from snippet generator 'properties; set job properties'
 // Time-based triggers added to execute nightly tests, eg '30 2 * * *' means 2:30 AM
 properties([
-    pipelineTriggers([cron('0 23 * * *'), [$class: 'PeriodicFolderTrigger', interval: '5m']]),
+    pipelineTriggers([cron('0 22 * * *'), [$class: 'PeriodicFolderTrigger', interval: '5m']]),
     buildDiscarder(logRotator(
       artifactDaysToKeepStr: '',
       artifactNumToKeepStr: '',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,7 +48,7 @@ rocSPARSECI:
         
         if(platform.jenkinsLabel.contains('hip-clang'))
         {
-            def command = """#!/usr/bin/env bash
+            command = """#!/usr/bin/env bash
                     set -x
                     cd ${project.paths.project_build_prefix}
                     LD_LIBRARY_PATH=/opt/rocm/hcc/lib CXX=/opt/rocm/bin/hipcc ${project.paths.build_command} --hip-clang

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,7 +34,7 @@ rocSPARSECI:
     rocsparse.paths.build_command = './install.sh -c'
     
     // Define test architectures, optional rocm version argument is available
-    def nodes = new dockerNodes(['gfx900 && centos7', 'gfx906 && ubuntu', 'gfx900 && ubuntu && hip-clang'], rocsparse)
+    def nodes = new dockerNodes(['gfx900 && centos7', 'gfx906 && ubuntu', 'gfx900 && ubuntu && hip-clang', 'gfx906 && ubuntu && hip-clang'], rocsparse)
 
     boolean formatCheck = true
 

--- a/docker/dockerfile-build-centos
+++ b/docker/dockerfile-build-centos
@@ -17,8 +17,6 @@ RUN yum install -y \
     devtoolset-7 \
     ca-certificates \
     git \
-    gcc \
-    gcc-c++ \
     gtest \
     gtest-devel \
     cmake3 \
@@ -37,8 +35,8 @@ RUN echo '#!/bin/bash' | tee /etc/profile.d/devtoolset7.sh && echo \
 # docker pipeline runs containers with particular uid
 # create a jenkins user with this specific uid so it can use sudo priviledges
 # Grant any member of sudo group password-less sudo privileges
-RUN useradd --create-home -u ${user_uid} -o -G wheel --shell /bin/bash jenkins && \
-    echo '%wheel ALL=(ALL) NOPASSWD:ALL' | tee /etc/sudoers.d/sudo-nopasswd && \
+RUN useradd --create-home -u ${user_uid} -o -G video --shell /bin/bash jenkins && \
+    echo '%video ALL=(ALL) NOPASSWD:ALL' | tee /etc/sudoers.d/sudo-nopasswd && \
     chmod 400 /etc/sudoers.d/sudo-nopasswd
     
 ARG ROCSPARSE_SRC_ROOT=/usr/local/src/rocSPARSE

--- a/docker/dockerfile-build-centos
+++ b/docker/dockerfile-build-centos
@@ -17,6 +17,8 @@ RUN yum install -y \
     devtoolset-7 \
     ca-certificates \
     git \
+    gcc \
+    gcc-c++ \
     gtest \
     gtest-devel \
     cmake3 \

--- a/docker/dockerfile-build-ubuntu-rock
+++ b/docker/dockerfile-build-ubuntu-rock
@@ -18,8 +18,6 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     build-essential \
     ca-certificates \
     git \
-    gcc \
-    g++ \
     make \
     cmake \
     clang-format-3.8 \

--- a/docker/dockerfile-build-ubuntu-rock
+++ b/docker/dockerfile-build-ubuntu-rock
@@ -20,7 +20,6 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     git \
     make \
     cmake \
-    clang-format-3.8 \
     pkg-config \
     libboost-program-options-dev \
     libnuma1 \

--- a/docker/dockerfile-build-ubuntu-rock
+++ b/docker/dockerfile-build-ubuntu-rock
@@ -18,6 +18,8 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     build-essential \
     ca-certificates \
     git \
+    gcc \
+    g++ \
     make \
     cmake \
     clang-format-3.8 \


### PR DESCRIPTION
This PR adds CI testing for our new hip-clang compiler. For a period of time, we'll have to support both the hcc and the hip-clang compilers, thus we'll have to test both in CI.
