### PR TITLE
csrgemm fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,7 @@ option(BUILD_VERBOSE "Output additional build information" OFF)
 include(cmake/Dependencies.cmake)
 
 # Setup version
-rocm_setup_version(VERSION 1.4.2)
+rocm_setup_version(VERSION 1.4.3)
 set(rocsparse_SOVERSION 0.1)
 
 # AMD targets

--- a/library/src/extra/rocsparse_csrgemm.cpp
+++ b/library/src/extra/rocsparse_csrgemm.cpp
@@ -716,6 +716,21 @@ static rocsparse_status rocsparse_csrgemm_nnz_scal(rocsparse_handle          han
     // Stream
     hipStream_t stream = handle->stream;
 
+    // Quick return if possible
+    if(m == 0 || n == 0 || nnz_D == 0)
+    {
+        if(handle->pointer_mode == rocsparse_pointer_mode_device)
+        {
+            RETURN_IF_HIP_ERROR(hipMemsetAsync(nnz_C, 0, sizeof(rocsparse_int), stream));
+        }
+        else
+        {
+            *nnz_C = 0;
+        }
+
+        return rocsparse_status_success;
+    }
+
     // When scaling a matrix, nnz of C will always be equal to nnz of D
     if(handle->pointer_mode == rocsparse_pointer_mode_device)
     {


### PR DESCRIPTION
quick return was missing when ``alpha == null`` and ``beta != null``