### PR TITLE
rocSPARSE Separate build flag to support multiple ROCM installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ else()
 endif()
 
 # CMake modules
-list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${ROCM_PATH}/hip/cmake /opt/rocm/hip/cmake)
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake /opt/rocm/hip/cmake)
 
 # Set a default build type if none was specified
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)

--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -48,11 +48,11 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 if(NOT TARGET rocsparse)
-  find_package(rocsparse REQUIRED CONFIG PATHS ${ROCM_PATH}/rocsparse /opt/rocm/rocsparse)
+  find_package(rocsparse REQUIRED CONFIG PATHS /opt/rocm/rocsparse)
 endif()
 
 # Hip headers required of all clients; clients use hip to allocate device memory
-list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH} /opt/rocm)
+list(APPEND CMAKE_PREFIX_PATH /opt/rocm)
 find_package(HIP REQUIRED CONFIG PATHS ${CMAKE_PREFIX_PATH})
 
 # Build flags

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -31,7 +31,7 @@ find_package(rocprim REQUIRED)
 
 # Workaround until hcc & hip cmake modules fixes symlink logic in their config files.
 # (Thanks to rocBLAS devs for finding workaround for this problem!)
-list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/hcc /opt/rocm/hcc ${ROCM_PATH}/hip /opt/rocm/hip ${ROCM_PATH} /opt/rocm)
+list(APPEND CMAKE_PREFIX_PATH /opt/rocm/hcc /opt/rocm/hip /opt/rocm)
 
 # HIP configuration
 if(CMAKE_CXX_COMPILER MATCHES ".*/hcc$")

--- a/cmake/Packaging.cmake
+++ b/cmake/Packaging.cmake
@@ -44,11 +44,11 @@ function(rocm_create_package_clients)
     if(EXISTS "${PROJECT_BINARY_DIR}/package")
         file(REMOVE_RECURSE "${PROJECT_BINARY_DIR}/package")
     endif()
-    file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/package/${CMAKE_INSTALL_PREFIX}/${PARSE_LIB_NAME}/bin")
+    file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/package/${ROCM_PATH}/${PARSE_LIB_NAME}/bin")
     file(WRITE "${PROJECT_BINARY_DIR}/package/DEBIAN/control" ${DEB_CONTROL_FILE_CONTENT})
 
     add_custom_target(package_clients
-        COMMAND ${CMAKE_COMMAND} -E remove -f "${PROJECT_BINARY_DIR}/package/${CMAKE_INSTALL_PREFIX}/${PARSE_LIB_NAME}/bin/*"
-        COMMAND ${CMAKE_COMMAND} -E copy "${PROJECT_BINARY_DIR}/staging/*" "${PROJECT_BINARY_DIR}/package/${CMAKE_INSTALL_PREFIX}/${PARSE_LIB_NAME}/bin"
+        COMMAND ${CMAKE_COMMAND} -E remove -f "${PROJECT_BINARY_DIR}/package/${ROCM_PATH}/${PARSE_LIB_NAME}/bin/*"
+        COMMAND ${CMAKE_COMMAND} -E copy "${PROJECT_BINARY_DIR}/staging/*" "${PROJECT_BINARY_DIR}/package/${ROCM_PATH}/${PARSE_LIB_NAME}/bin"
         COMMAND dpkg -b "${PROJECT_BINARY_DIR}/package/"  ${PACKAGE_NAME})
 endfunction(rocm_create_package_clients)

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -59,11 +59,6 @@ include(src/CMakeLists.txt)
 add_library(rocsparse ${rocsparse_source} ${rocsparse_headers_public})
 add_library(roc::rocsparse ALIAS rocsparse)
 
-# RUNPATH is set only when ROCM_RPATH is defined in the ENV
-if( DEFINED ENV{ROCM_RPATH} )
-  set ( CMAKE_SHARED_LINKER_FLAGS " -Wl,--enable-new-dtags -Wl,--rpath,$ENV{ROCM_RPATH}" )
-endif( )
-
 # Target compile options
 target_compile_options(rocsparse PRIVATE -fno-gpu-rdc)
 foreach(target ${AMDGPU_TARGETS})
@@ -129,7 +124,7 @@ set(CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION "\${CPACK_PACKAGING_INSTALL_PR
 # Package name
 set(package_name rocsparse)
 
-set(ROCSPARSE_CONFIG_DIR "/opt/rocm/${CMAKE_INSTALL_LIBDIR}" CACHE PATH "Path placed into ldconfig file")
+set(ROCSPARSE_CONFIG_DIR "\${CPACK_PACKAGING_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}" CACHE PATH "Path placed into ldconfig file")
 
 rocm_create_package(
   NAME ${package_name}


### PR DESCRIPTION
- New mode of building is added "-r,--relocatable" which is used
  for ROCm stack installed in /opt/rocm-ver.
- Below CMAKE parameters are set/overwritten in above mode
  CMAKE_INSTALL_PREFIX
  CPACK_PACKAGING_INSTALL_PREFIX
  CMAKE_PREFIX_PATH
  CMAKE_SHARED_LINKER_FLAGS
  ROCM_DISABLE_LDCONFIG
  ROCM_PATH

Signed-off-by: Pruthvi Madugundu <mpruthvi@gmail.com>