### PR TITLE
Fix CMAKE_INSTALL_PREFIX in build_relocatable

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -376,7 +376,7 @@ pushd .
   # Build library with AMD toolchain because of existense of device kernels
   if [[ "${build_relocatable}" == true ]]; then
     CXX=${compiler} ${cmake_executable} ${cmake_common_options} ${cmake_client_options} -DCPACK_SET_DESTDIR=OFF \
-      -DCMAKE_INSTALL_PREFIX=${rocm_path} \
+      -DCMAKE_INSTALL_PREFIX=${install_prefix} \
       -DCPACK_PACKAGING_INSTALL_PREFIX=${rocm_path} \
       -DCMAKE_SHARED_LINKER_FLAGS=${rocm_rpath} \
       -DCMAKE_PREFIX_PATH="${rocm_path} ${rocm_path}/hcc ${rocm_path}/hip" \


### PR DESCRIPTION
-> CMAKE_INSTALL_PREFIX set to $install_prefix for 'make install'
-> CPACK_PACKAGING_INSTALL_PREFIX still set to $rocm_path for package install path
-> 'make install' can be called by non-root user to test the build