### PR TITLE
use appropriate export target for HIP

### DIFF
--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -109,7 +109,7 @@ rocm_install_targets(TARGETS rocsparse
 # Export targets
 rocm_export_targets(TARGETS roc::rocsparse
                     PREFIX rocsparse
-                    DEPENDS PACKAGE hip
+                    DEPENDS PACKAGE HIP
                     NAMESPACE roc::
 )
 


### PR DESCRIPTION
resolves #207 

Summary of proposed changes:
-  change find_package( hip ... calls to find_package( HIP ... to match the FindHIP.cmake file as installed by hip-base.
-  change export dep from hip to HIP
