### PR TITLE
Remove boz literals

### DIFF
--- a/library/src/rocsparse_module.f90
+++ b/library/src/rocsparse_module.f90
@@ -99,9 +99,9 @@ module rocsparse
 
 !   rocsparse_layer_mode
     enum, bind(c)
-        enumerator :: rocsparse_layer_mode_none = x'0'
-        enumerator :: rocsparse_layer_mode_log_trace = x'1'
-        enumerator :: rocsparse_layer_mode_log_bench = x'2'
+        enumerator :: rocsparse_layer_mode_none = 0
+        enumerator :: rocsparse_layer_mode_log_trace = 1
+        enumerator :: rocsparse_layer_mode_log_bench = 2
     end enum
 
 !   rocsparse_status


### PR DESCRIPTION
The usage of `x` for hex numbers is a `gfortran` extension, not supported by newer versions like `gfortran 10.2`.
Furthermore, the usage of boz literals in enums is not supported by the fortran standard, neither in `f90` nor in `f18`.
