### PR TITLE
Replace old xnack off compiler flag with new version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,7 @@ option(BUILD_VERBOSE "Output additional build information" OFF)
 include(cmake/Dependencies.cmake)
 
 # Setup version
-set(VERSION_STRING "1.17.7")
+set(VERSION_STRING "1.17.8")
 rocm_setup_version(VERSION ${VERSION_STRING})
 set(rocsparse_SOVERSION 0.1)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,7 @@ option(BUILD_VERBOSE "Output additional build information" OFF)
 include(cmake/Dependencies.cmake)
 
 # Setup version
-set(VERSION_STRING "1.17.6")
+set(VERSION_STRING "1.17.7")
 rocm_setup_version(VERSION ${VERSION_STRING})
 set(rocsparse_SOVERSION 0.1)
 

--- a/clients/include/testing_prune_csr2csr_by_percentage.hpp
+++ b/clients/include/testing_prune_csr2csr_by_percentage.hpp
@@ -725,8 +725,6 @@ void testing_prune_csr2csr_by_percentage(const Arguments& arg)
                               false,
                               full_rank);
 
-    //std::cout << "M: " << M << " N: " << N << " nnz_A: " << nnz_A << " percentage: " << percentage << std::endl;
-
     // Argument sanity check before allocating invalid memory
     if(nnz_A <= 0)
     {
@@ -750,20 +748,6 @@ void testing_prune_csr2csr_by_percentage(const Arguments& arg)
 
         return;
     }
-
-    // std::cout << "h_csr_row_ptr_A" << std::endl;
-    // for(size_t i = 0; i < h_csr_row_ptr_A.size(); i++)
-    // {
-    //     std::cout << h_csr_row_ptr_A[i] << " ";
-    // }
-    // std::cout << "" << std::endl;
-
-    // std::cout << "h_csr_val_A" << std::endl;
-    // for(size_t i = 0; i < h_csr_val_A.size(); i++)
-    // {
-    //     std::cout << h_csr_val_A[i] << " ";
-    // }
-    // std::cout << "" << std::endl;
 
     // Allocate device memory for input CSR matrix
     device_vector<rocsparse_int> d_nnz_total_dev_host_ptr(1);

--- a/clients/tests/test_csrsm.yaml
+++ b/clients/tests/test_csrsm.yaml
@@ -68,7 +68,7 @@ Tests:
   M_N: *M_N_range_quick
   K: [1, 23, 65, 153, 280]
   alpha_alphai: *alpha_range_quick
-  transA: [rocsparse_operation_none]
+  transA: [rocsparse_operation_transpose]
   transB: [rocsparse_operation_none]
   diag: [rocsparse_diag_type_non_unit]
   uplo: [rocsparse_fill_mode_lower]
@@ -139,7 +139,7 @@ Tests:
   N: 1
   K: [-1, 0, 7, 141]
   alpha_alphai: *alpha_range_checkin
-  transA: [rocsparse_operation_none]
+  transA: [rocsparse_operation_transpose]
   transB: [rocsparse_operation_none]
   diag: [rocsparse_diag_type_non_unit]
   uplo: [rocsparse_fill_mode_upper]
@@ -163,7 +163,7 @@ Tests:
   N: 1
   K: [16, 96, 218]
   alpha_alphai: *alpha_range_nightly
-  transA: [rocsparse_operation_none]
+  transA: [rocsparse_operation_transpose]
   transB: [rocsparse_operation_transpose]
   diag: [rocsparse_diag_type_non_unit]
   uplo: [rocsparse_fill_mode_lower]
@@ -220,7 +220,7 @@ Tests:
   N: 1
   K: [23, 71, 111]
   alpha_alphai: *alpha_range_nightly
-  transA: [rocsparse_operation_none]
+  transA: [rocsparse_operation_transpose]
   transB: [rocsparse_operation_none]
   diag: [rocsparse_diag_type_unit]
   uplo: [rocsparse_fill_mode_upper]

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -70,9 +70,8 @@ add_library(rocsparse ${rocsparse_source} ${rocsparse_headers_public})
 add_library(roc::rocsparse ALIAS rocsparse)
 
 # Target compile options
-target_compile_options(rocsparse PRIVATE -mno-xnack -Xarch_gfx906 -mno-sram-ecc -Xarch_gfx908 -msram-ecc)
 foreach(target ${AMDGPU_TARGETS})
-  target_compile_options(rocsparse PRIVATE --amdgpu-target=${target})
+  target_compile_options(rocsparse PRIVATE --amdgpu-target=${target}:xnack-)
 endforeach()
 
 # Target include directories

--- a/library/include/rocsparse-functions.h
+++ b/library/include/rocsparse-functions.h
@@ -3119,7 +3119,7 @@ rocsparse_status rocsparse_csrsm_zero_pivot(rocsparse_handle   handle,
 *              is invalid.
 *  \retval     rocsparse_status_internal_error an internal error occurred.
 *  \retval     rocsparse_status_not_implemented
-*              \p trans_A != \ref rocsparse_operation_none,
+*              \p trans_A == \ref rocsparse_operation_conjugate_transpose,
 *              \p trans_B == \ref rocsparse_operation_conjugate_transpose or
 *              \ref rocsparse_matrix_type != \ref rocsparse_matrix_type_general.
 */
@@ -3272,7 +3272,7 @@ rocsparse_status rocsparse_zcsrsm_buffer_size(rocsparse_handle                ha
 *              is invalid.
 *  \retval     rocsparse_status_internal_error an internal error occurred.
 *  \retval     rocsparse_status_not_implemented
-*              \p trans_A != \ref rocsparse_operation_none,
+*              \p trans_A == \ref rocsparse_operation_conjugate_transpose,
 *              \p trans_B == \ref rocsparse_operation_conjugate_transpose or
 *              \ref rocsparse_matrix_type != \ref rocsparse_matrix_type_general.
 */
@@ -3442,7 +3442,7 @@ rocsparse_status rocsparse_csrsm_clear(rocsparse_handle handle, rocsparse_mat_in
 *  It may return before the actual computation has finished.
 *
 *  \note
-*  Currently, only \p trans_A == \ref rocsparse_operation_none and
+*  Currently, only \p trans_A != \ref rocsparse_operation_conjugate_transpose and
 *  \p trans_B != \ref rocsparse_operation_conjugate_transpose is supported.
 *
 *  @param[in]
@@ -3488,7 +3488,7 @@ rocsparse_status rocsparse_csrsm_clear(rocsparse_handle handle, rocsparse_mat_in
 *              is invalid.
 *  \retval     rocsparse_status_internal_error an internal error occurred.
 *  \retval     rocsparse_status_not_implemented
-*              \p trans_A != \ref rocsparse_operation_none,
+*              \p trans_A == \ref rocsparse_operation_conjugate_transpose,
 *              \p trans_B == \ref rocsparse_operation_conjugate_transpose or
 *              \ref rocsparse_matrix_type != \ref rocsparse_matrix_type_general.
 *

--- a/library/src/level2/rocsparse_csrsv.hpp
+++ b/library/src/level2/rocsparse_csrsv.hpp
@@ -750,6 +750,13 @@ rocsparse_status rocsparse_csrsv_analysis_template(rocsparse_handle          han
                 info->csrsv_upper_info = info->csrsm_upper_info;
                 return rocsparse_status_success;
             }
+
+            if(trans == rocsparse_operation_transpose && info->csrsmt_upper_info != nullptr)
+            {
+                // csrsv meta data
+                info->csrsvt_upper_info = info->csrsmt_upper_info;
+                return rocsparse_status_success;
+            }
         }
 
         // User is explicitly asking to force a re-analysis, or no valid data has been
@@ -818,6 +825,12 @@ rocsparse_status rocsparse_csrsv_analysis_template(rocsparse_handle          han
             {
                 // csrsm meta data
                 info->csrsv_lower_info = info->csrsm_lower_info;
+                return rocsparse_status_success;
+            }
+            else if(trans == rocsparse_operation_transpose && info->csrsmt_lower_info != nullptr)
+            {
+                // csrsm meta data
+                info->csrsvt_lower_info = info->csrsmt_lower_info;
                 return rocsparse_status_success;
             }
         }

--- a/library/src/precond/rocsparse_csric0.hpp
+++ b/library/src/precond/rocsparse_csric0.hpp
@@ -157,10 +157,22 @@ rocsparse_status rocsparse_csric0_analysis_template(rocsparse_handle          ha
             info->csric0_info = info->csrsv_lower_info;
             return rocsparse_status_success;
         }
+        else if(info->csrsvt_upper_info != nullptr)
+        {
+            // csrsvt meta data
+            info->csric0_info = info->csrsvt_upper_info;
+            return rocsparse_status_success;
+        }
         else if(info->csrsm_lower_info != nullptr)
         {
             // csrsm meta data
             info->csric0_info = info->csrsm_lower_info;
+            return rocsparse_status_success;
+        }
+        else if(info->csrsmt_upper_info != nullptr)
+        {
+            // csrsmt meta data
+            info->csric0_info = info->csrsmt_upper_info;
             return rocsparse_status_success;
         }
     }

--- a/library/src/precond/rocsparse_csrilu0.hpp
+++ b/library/src/precond/rocsparse_csrilu0.hpp
@@ -210,10 +210,22 @@ rocsparse_status rocsparse_csrilu0_analysis_template(rocsparse_handle          h
             info->csrilu0_info = info->csrsv_lower_info;
             return rocsparse_status_success;
         }
+        else if(info->csrsvt_upper_info != nullptr)
+        {
+            // csrsvt meta data
+            info->csrilu0_info = info->csrsvt_upper_info;
+            return rocsparse_status_success;
+        }
         else if(info->csrsm_lower_info != nullptr)
         {
             // csrsm meta data
             info->csrilu0_info = info->csrsm_lower_info;
+            return rocsparse_status_success;
+        }
+        else if(info->csrsmt_upper_info != nullptr)
+        {
+            // csrsmt meta data
+            info->csrilu0_info = info->csrsmt_upper_info;
             return rocsparse_status_success;
         }
     }


### PR DESCRIPTION
Summary of proposed changes:
- Replace old version of xnack compiler off flag with the new syntax for the flag
