### PR TITLE
Fix Jenkins docs link and minor cleanup

### DIFF
--- a/.jenkins/staticanalysis.groovy
+++ b/.jenkins/staticanalysis.groovy
@@ -32,7 +32,7 @@ def runCompileCommand(platform, project, jobName, boolean debug=false)
     publishHTML([allowMissing: false,
                 alwaysLinkToLastBuild: false,
                 keepAll: false,
-                reportDir: "${project.paths.project_build_prefix}/docs/docBin/html",
+                reportDir: "${project.paths.project_build_prefix}/docs/source/_build/html",
                 reportFiles: "index.html",
                 reportName: "Documentation",
                 reportTitles: "Documentation"])

--- a/.jenkins/staticanalysis.groovy
+++ b/.jenkins/staticanalysis.groovy
@@ -15,9 +15,7 @@ def runCompileCommand(platform, project, jobName, boolean debug=false)
 
     def command = """#!/usr/bin/env bash
             set -x
-            pushd  ${project.paths.project_build_prefix}/docs
-            ./run_doc.sh
-            popd
+            ${project.paths.project_build_prefix}/docs/run_doc.sh
             """
 
     try

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -777,8 +777,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = modules.dox \
-                         ../
+INPUT                  = ../library/include
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -2029,7 +2028,7 @@ ENABLE_PREPROCESSING   = YES
 # The default value is: NO.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-MACRO_EXPANSION        = NO
+MACRO_EXPANSION        = YES
 
 # If the EXPAND_ONLY_PREDEF and MACRO_EXPANSION tags are both set to YES then
 # the macro expansion is limited to the macros specified with the PREDEFINED and
@@ -2037,14 +2036,14 @@ MACRO_EXPANSION        = NO
 # The default value is: NO.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-EXPAND_ONLY_PREDEF     = NO
+EXPAND_ONLY_PREDEF     = YES
 
 # If the SEARCH_INCLUDES tag is set to YES, the include files in the
 # INCLUDE_PATH will be searched if a #include is found.
 # The default value is: YES.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-SEARCH_INCLUDES        = YES
+SEARCH_INCLUDES        = NO
 
 # The INCLUDE_PATH tag can be used to specify one or more directories that
 # contain include files that are not input files but should be processed by the
@@ -2069,7 +2068,9 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             = 
+PREDEFINED             = __attribute__(x)= \
+                         __inline= \
+                         ROCSPARSE_EXPORT=
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/docs/run_doc.sh
+++ b/docs/run_doc.sh
@@ -1,17 +1,22 @@
 #!/bin/bash
 
-if [ -d docBin ]; then
-    rm -rf docBin
-fi
+set -eu
 
+# Make this directory the PWD
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+# Update version string
 cur_version=$(sed -n -e "s/^.*VERSION_STRING.* \"\([0-9\.]\{1,\}\).*/\1/p" ../CMakeLists.txt)
 sed -i -e "s/\(PROJECT_NUMBER.*=\)\(.*\)/\1 v${cur_version}/" Doxyfile
 sed -i -e "s/\(version.*=\)\(.*\)/\1 u'${cur_version}'/" source/conf.py
 sed -i -e "s/\(release.*=\)\(.*\)/\1 u'${cur_version}'/" source/conf.py
+
+# Build doxygen info
+rm -rf docBin
 doxygen Doxyfile
 
+# Build sphinx docs
 cd source
 make clean
 make html
 make latexpdf
-cd ..

--- a/docs/run_doc.sh
+++ b/docs/run_doc.sh
@@ -8,12 +8,6 @@ cur_version=$(sed -n -e "s/^.*VERSION_STRING.* \"\([0-9\.]\{1,\}\).*/\1/p" ../CM
 sed -i -e "s/\(PROJECT_NUMBER.*=\)\(.*\)/\1 v${cur_version}/" Doxyfile
 sed -i -e "s/\(version.*=\)\(.*\)/\1 u'${cur_version}'/" source/conf.py
 sed -i -e "s/\(release.*=\)\(.*\)/\1 u'${cur_version}'/" source/conf.py
-
-sed -e 's/ROCSPARSE_EXPORT//g' ../library/include/rocsparse-functions.h > rocsparse-functions.h
-sed -e 's/ROCSPARSE_EXPORT//g' ../library/include/rocsparse-auxiliary.h > rocsparse-auxiliary.h
-sed -i 's/#include "rocsparse-export.h"//g' rocsparse-functions.h
-sed -i 's/#include "rocsparse-export.h"//g' rocsparse-auxiliary.h
-cp ../library/include/rocsparse-types.h rocsparse-types.h
 doxygen Doxyfile
 
 cd source
@@ -21,7 +15,3 @@ make clean
 make html
 make latexpdf
 cd ..
-
-rm rocsparse-functions.h
-rm rocsparse-auxiliary.h
-rm rocsparse-types.h

--- a/docs/run_doxygen.sh
+++ b/docs/run_doxygen.sh
@@ -1,10 +1,14 @@
 #!/bin/bash
 
-if [ -d docBin ]; then
-    rm -rf docBin
-fi
+set -eu
 
-cur_version=$(sed -n -e "s/^.*VERSION_STRING.* \"\([0-9\.]\{1,\}\).*/\1/p" ../CMakeLists.txt)
+# Make this directory the PWD
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+# Update version string
+# cur_version=$(sed -n -e "s/^.*VERSION_STRING.* \"\([0-9\.]\{1,\}\).*/\1/p" ../CMakeLists.txt)
 # sed -i -e "s/\(PROJECT_NUMBER.*=\)\(.*\)/\1 v${cur_version}/" Doxyfile
 
+# Build the doxygen info
+rm -rf docBin
 doxygen Doxyfile

--- a/docs/run_doxygen.sh
+++ b/docs/run_doxygen.sh
@@ -7,12 +7,4 @@ fi
 cur_version=$(sed -n -e "s/^.*VERSION_STRING.* \"\([0-9\.]\{1,\}\).*/\1/p" ../CMakeLists.txt)
 # sed -i -e "s/\(PROJECT_NUMBER.*=\)\(.*\)/\1 v${cur_version}/" Doxyfile
 
-sed -e 's/ROCSPARSE_EXPORT//g' ../library/include/rocsparse-functions.h > rocsparse-functions.h
-sed -e 's/ROCSPARSE_EXPORT//g' ../library/include/rocsparse-auxiliary.h > rocsparse-auxiliary.h
-sed -i 's/#include "rocsparse-export.h"//g' rocsparse-functions.h
-sed -i 's/#include "rocsparse-export.h"//g' rocsparse-auxiliary.h
-cp ../library/include/rocsparse-types.h rocsparse-types.h
 doxygen Doxyfile
-rm rocsparse-functions.h
-rm rocsparse-auxiliary.h
-rm rocsparse-types.h

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -27,7 +27,7 @@ import subprocess
 read_the_docs_build = os.environ.get('READTHEDOCS', None) == 'True'
 
 if read_the_docs_build:
-    subprocess.call('cd ..; ./run_doxygen.sh; cd source', shell=True)
+    subprocess.call('../run_doxygen.sh')
 
 # -- General configuration ------------------------------------------------
 


### PR DESCRIPTION
I've updated the Jenkins config to host the Sphinx docs for each PR. I also ported over some of the doc script improvements I made on rocBLAS and rocSOLVER.

Summary of proposed changes:
- Switch documentation link on Jenkins from Doxygen to Sphinx output
- Configure Doxygen to process headers in-place
- Allow doc scripts to run from anywhere
