### PR TITLE
Support new clang string for ROCmCC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,8 @@ string(REGEX MATCH "[A-Za-z]* ?clang version" TMP_CXX_VERSION ${CXX_OUTPUT})
 string(REGEX MATCH "[A-Za-z]+" CXX_VERSION_STRING ${TMP_CXX_VERSION})
 
 # Print compiler information
-if(CXX_VERSION_STRING MATCHES "clang")
+if(CXX_VERSION_STRING MATCHES "clang" OR 
+   CXX_VERSION_STRING MATCHES "AMD")
   message(STATUS "Using hip-clang to build for amdgpu backend")
 else()
   message(FATAL_ERROR "'hipcc' compiler required to compile for ROCm platform.")


### PR DESCRIPTION
The vendor string "AMD" is being added to ROCm clang compiler.  This updates the compiler version check in cmake.