### PR TITLE
Detect Clang using the compiler ID

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,15 +54,7 @@ endif()
 project(rocsparse LANGUAGES CXX Fortran)
 
 # Determine if CXX Compiler is hip-clang
-execute_process(COMMAND ${CMAKE_CXX_COMPILER} "--version" OUTPUT_VARIABLE CXX_OUTPUT
-                OUTPUT_STRIP_TRAILING_WHITESPACE
-                ERROR_STRIP_TRAILING_WHITESPACE)
-string(REGEX MATCH "[A-Za-z]* ?clang version" TMP_CXX_VERSION ${CXX_OUTPUT})
-string(REGEX MATCH "[A-Za-z]+" CXX_VERSION_STRING ${TMP_CXX_VERSION})
-
-# Print compiler information
-if(CXX_VERSION_STRING MATCHES "clang" OR 
-   CXX_VERSION_STRING MATCHES "AMD")
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   message(STATUS "Using hip-clang to build for amdgpu backend")
 else()
   message(FATAL_ERROR "'hipcc' compiler required to compile for ROCm platform.")

--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -42,14 +42,7 @@ endif()
 project(rocsparse-clients LANGUAGES CXX)
 
 # Determine if CXX Compiler is hip-clang
-execute_process(COMMAND ${CMAKE_CXX_COMPILER} "--version" OUTPUT_VARIABLE CXX_OUTPUT
-                OUTPUT_STRIP_TRAILING_WHITESPACE
-                ERROR_STRIP_TRAILING_WHITESPACE)
-string(REGEX MATCH "[A-Za-z]* ?clang version" TMP_CXX_VERSION ${CXX_OUTPUT})
-string(REGEX MATCH "[A-Za-z]+" CXX_VERSION_STRING ${TMP_CXX_VERSION})
-
-# Print compiler information
-if(CXX_VERSION_STRING MATCHES "clang")
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   message(STATUS "Using hip-clang to build for amdgpu backend")
 else()
   message(FATAL_ERROR "'hipcc' compiler required to compile for ROCm platform.")


### PR DESCRIPTION
Check the CMAKE_CXX_COMPILER_ID string instead of parsing the
Clang version string.