### PR TITLE
Hybrid algorithm to use bisection search or hash table in CSR ILU0

### DIFF
--- a/library/src/precond/bisection_algorithm.h
+++ b/library/src/precond/bisection_algorithm.h
@@ -1,0 +1,132 @@
+auto bisection_algorithm = [=](auto const row) -> void {
+    // Diagonal entry point of the current row
+    rocsparse_int row_diag = csr_diag_ind[row];
+
+    // Row entry point
+    rocsparse_int row_begin = csr_row_ptr[row] - idx_base;
+    rocsparse_int row_end   = csr_row_ptr[row + 1] - idx_base;
+
+    // Loop over column of current row
+    for(rocsparse_int j = row_begin; j < row_diag; ++j)
+    {
+        // Column index currently being processes
+        rocsparse_int local_col = csr_col_ind[j] - idx_base;
+
+        // Corresponding value
+        T local_val = csr_val[j];
+
+        // End of the row that corresponds to local_col
+        rocsparse_int local_end = csr_row_ptr[local_col + 1] - idx_base;
+
+        // Diagonal entry point of row local_col
+        rocsparse_int local_diag = csr_diag_ind[local_col];
+
+        // Structural zero pivot, do not process this row
+        if(local_diag == -1)
+        {
+            local_diag = local_end - 1;
+        }
+
+        // Spin loop until dependency has been resolved
+        int          local_done    = atomicOr(&done[local_col], 0);
+        unsigned int times_through = 0;
+        while(!local_done)
+        {
+            if(SLEEP)
+            {
+                for(unsigned int i = 0; i < times_through; ++i)
+                {
+                    __builtin_amdgcn_s_sleep(1);
+                }
+
+                if(times_through < 3907)
+                {
+                    ++times_through;
+                }
+            }
+
+            local_done = atomicOr(&done[local_col], 0);
+        }
+
+        // Make sure updated csr_val is visible
+        __threadfence();
+
+        // Load diagonal entry
+        T diag_val = csr_val[local_diag];
+
+        // Numeric boost
+        if(boost)
+        {
+            diag_val = (boost_tol >= rocsparse_abs(diag_val)) ? boost_val : diag_val;
+
+            __threadfence();
+
+            if(lid == 0)
+            {
+                csr_val[local_diag] = diag_val;
+            }
+        }
+        else
+        {
+            // Row has numerical zero diagonal
+            if(diag_val == static_cast<T>(0))
+            {
+                if(lid == 0)
+                {
+                    // We are looking for the first zero pivot
+                    atomicMin(zero_pivot, local_col + idx_base);
+                }
+
+                // Skip this row if it has a zero pivot
+                break;
+            }
+        }
+
+        csr_val[j] = local_val = local_val / diag_val;
+
+        // Loop over the row the current column index depends on
+        // Each lane processes one entry
+        rocsparse_int l = j + 1;
+        for(rocsparse_int k = local_diag + 1 + lid; k < local_end; k += WFSIZE)
+        {
+            // Perform a binary search to find matching columns
+            rocsparse_int r     = row_end - 1;
+            rocsparse_int m     = (r + l) >> 1;
+            rocsparse_int col_j = csr_col_ind[m];
+
+            rocsparse_int col_k = csr_col_ind[k];
+
+            // Binary search
+            while(l < r)
+            {
+                if(col_j < col_k)
+                {
+                    l = m + 1;
+                }
+                else
+                {
+                    r = m;
+                }
+
+                m     = (r + l) >> 1;
+                col_j = csr_col_ind[m];
+            }
+
+            // Check if a match has been found
+            if(col_j == col_k)
+            {
+                // If a match has been found, do ILU computation
+                csr_val[l] = rocsparse_fma(-local_val, csr_val[k], csr_val[l]);
+            }
+        }
+    }
+
+    // Make sure updated csr_val is written to global memory
+    __threadfence();
+
+    if(lid == 0)
+    {
+        // First lane writes "we are done" flag
+        atomicOr(&done[row], 1);
+    }
+};

--- a/library/src/precond/bisection_algorithm.h
+++ b/library/src/precond/bisection_algorithm.h
@@ -1,3 +1,27 @@
+
+/*! \file */
+/* ************************************************************************
+ * Copyright (c) 2018-2021 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * ************************************************************************ */
 auto bisection_algorithm = [=](auto const row) -> void {
     // Diagonal entry point of the current row
     rocsparse_int row_diag = csr_diag_ind[row];

--- a/library/src/precond/hash_algorithm.h
+++ b/library/src/precond/hash_algorithm.h
@@ -1,3 +1,27 @@
+
+/*! \file */
+/* ************************************************************************
+ * Copyright (c) 2018-2021 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * ************************************************************************ */
 auto hash_algorithm = [=](auto const row) -> void {
     // Diagonal entry point of the current row
     rocsparse_int row_diag = csr_diag_ind[row];

--- a/library/src/precond/hash_algorithm.h
+++ b/library/src/precond/hash_algorithm.h
@@ -1,0 +1,146 @@
+auto hash_algorithm = [=](auto const row) -> void {
+    // Diagonal entry point of the current row
+    rocsparse_int row_diag = csr_diag_ind[row];
+
+    // Row entry point
+    rocsparse_int row_begin = csr_row_ptr[row] - idx_base;
+    rocsparse_int row_end   = csr_row_ptr[row + 1] - idx_base;
+
+    // Fill hash table
+    // Loop over columns of current row and fill hash table with row dependencies
+    // Each lane processes one entry
+    for(rocsparse_int j = row_begin + lid; j < row_end; j += WFSIZE)
+    {
+        // Insert key into hash table
+        rocsparse_int key = csr_col_ind[j];
+        // Compute hash
+        rocsparse_int hash = (key * 103) & (WFSIZE * HASH - 1);
+
+        // Hash operation
+        while(true)
+        {
+            if(table[hash] == key)
+            {
+                // key is already inserted, done
+                break;
+            }
+            else if(atomicCAS(&table[hash], -1, key) == -1)
+            {
+                // inserted key into the table, done
+                data[hash] = j;
+                break;
+            }
+            else
+            {
+                // collision, compute new hash
+                hash = (hash + 1) & (WFSIZE * HASH - 1);
+            }
+        }
+    }
+
+    __threadfence_block();
+
+    // Loop over column of current row
+    for(rocsparse_int j = row_begin; j < row_diag; ++j)
+    {
+        // Column index currently being processes
+        rocsparse_int local_col = csr_col_ind[j] - idx_base;
+
+        // Corresponding value
+        T local_val = csr_val[j];
+
+        // End of the row that corresponds to local_col
+        rocsparse_int local_end = csr_row_ptr[local_col + 1] - idx_base;
+
+        // Diagonal entry point of row local_col
+        rocsparse_int local_diag = csr_diag_ind[local_col];
+
+        // Structural zero pivot, do not process this row
+        if(local_diag == -1)
+        {
+            local_diag = local_end - 1;
+        }
+
+        // Spin loop until dependency has been resolved
+        while(!atomicOr(&done[local_col], 0))
+            ;
+
+        // Make sure updated csr_val is visible
+        __threadfence();
+
+        // Load diagonal entry
+        T diag_val = csr_val[local_diag];
+
+        // Numeric boost
+        if(boost)
+        {
+            diag_val = (boost_tol >= rocsparse_abs(diag_val)) ? boost_val : diag_val;
+
+            __threadfence();
+
+            if(lid == 0)
+            {
+                csr_val[local_diag] = diag_val;
+            }
+        }
+        else
+        {
+            // Row has numerical zero diagonal
+            if(diag_val == static_cast<T>(0))
+            {
+                if(lid == 0)
+                {
+                    // We are looking for the first zero pivot
+                    atomicMin(zero_pivot, local_col + idx_base);
+                }
+
+                // Skip this row if it has a zero pivot
+                break;
+            }
+        }
+
+        csr_val[j] = local_val = local_val / diag_val;
+
+        // Loop over the row the current column index depends on
+        // Each lane processes one entry
+        for(rocsparse_int k = local_diag + 1 + lid; k < local_end; k += WFSIZE)
+        {
+            // Get value from hash table
+            rocsparse_int key = csr_col_ind[k];
+
+            // Compute hash
+            rocsparse_int hash = (key * 103) & (WFSIZE * HASH - 1);
+
+            // Hash operation
+            while(true)
+            {
+                if(table[hash] == -1)
+                {
+                    // No entry for the key, done
+                    break;
+                }
+                else if(table[hash] == key)
+                {
+                    // Entry found, do ILU computation
+                    rocsparse_int idx_data = data[hash];
+                    csr_val[idx_data] = rocsparse_fma(-local_val, csr_val[k], csr_val[idx_data]);
+                    break;
+                }
+                else
+                {
+                    // Collision, compute new hash
+                    hash = (hash + 1) & (WFSIZE * HASH - 1);
+                }
+            }
+        }
+    }
+
+    // Make sure updated csr_val is written to global memory
+    __threadfence();
+
+    if(lid == 0)
+    {
+        // First lane writes "we are done" flag
+        atomicOr(&done[row], 1);
+    }
+};

--- a/library/src/precond/rocsparse_csrilu0.hpp
+++ b/library/src/precond/rocsparse_csrilu0.hpp
@@ -435,12 +435,10 @@ rocsparse_status rocsparse_csrilu0_dispatch(rocsparse_handle          handle,
     }
     else
     {
-#undef USE_ORIGINAL
         if(handle->wavefront_size == 32)
         {
 
 
-#ifdef USE_ORIGINAL
             if(max_nnz <= 32)
             {
                 hipLaunchKernelGGL((csrilu0_hash<CSRILU0_DIM, 32, 1>),
@@ -543,6 +541,8 @@ rocsparse_status rocsparse_csrilu0_dispatch(rocsparse_handle          handle,
             }
             else
             {
+
+#ifdef USE_ORIGINAL
                 hipLaunchKernelGGL((csrilu0_binsearch<CSRILU0_DIM, 32, false>),
                                    csrilu0_blocks,
                                    csrilu0_threads,
@@ -560,8 +560,10 @@ rocsparse_status rocsparse_csrilu0_dispatch(rocsparse_handle          handle,
                                    info->boost_enable,
                                    boost_tol_device_host,
                                    boost_val_device_host);
-            }
 #else
+                // ------------------------
+                // use new hybrid algorithm
+                // ------------------------
 
                 hipLaunchKernelGGL((csrilu0_hybrid<CSRILU0_DIM, 32, 4,false>),
                                    csrilu0_blocks,
@@ -582,10 +584,10 @@ rocsparse_status rocsparse_csrilu0_dispatch(rocsparse_handle          handle,
                                    boost_val_device_host);
 
 #endif
+            }
         }
         else if(handle->wavefront_size == 64)
         {
-#ifdef USE_ORIGINAL
             if(max_nnz <= 64)
             {
                 hipLaunchKernelGGL((csrilu0_hash<CSRILU0_DIM, 64, 1>),
@@ -688,6 +690,7 @@ rocsparse_status rocsparse_csrilu0_dispatch(rocsparse_handle          handle,
             }
             else
             {
+#ifdef USE_ORIGINAL
                 hipLaunchKernelGGL((csrilu0_binsearch<CSRILU0_DIM, 64, false>),
                                    csrilu0_blocks,
                                    csrilu0_threads,
@@ -705,7 +708,6 @@ rocsparse_status rocsparse_csrilu0_dispatch(rocsparse_handle          handle,
                                    info->boost_enable,
                                    boost_tol_device_host,
                                    boost_val_device_host);
-            }
 
 #else
                 hipLaunchKernelGGL((csrilu0_hybrid<CSRILU0_DIM, 64, 2,false>),
@@ -726,6 +728,7 @@ rocsparse_status rocsparse_csrilu0_dispatch(rocsparse_handle          handle,
                                    boost_tol_device_host,
                                    boost_val_device_host);
 #endif
+            }
         }
         else
         {

--- a/library/src/precond/rocsparse_csrilu0.hpp
+++ b/library/src/precond/rocsparse_csrilu0.hpp
@@ -563,7 +563,7 @@ rocsparse_status rocsparse_csrilu0_dispatch(rocsparse_handle          handle,
             }
 #else
 
-                hipLaunchKernelGGL((csrilu0_hybrid<CSRILU0_DIM, 32, 1,false>),
+                hipLaunchKernelGGL((csrilu0_hybrid<CSRILU0_DIM, 32, 4,false>),
                                    csrilu0_blocks,
                                    csrilu0_threads,
                                    0,
@@ -585,6 +585,7 @@ rocsparse_status rocsparse_csrilu0_dispatch(rocsparse_handle          handle,
         }
         else if(handle->wavefront_size == 64)
         {
+#ifdef USE_ORIGINAL
             if(max_nnz <= 64)
             {
                 hipLaunchKernelGGL((csrilu0_hash<CSRILU0_DIM, 64, 1>),
@@ -705,6 +706,26 @@ rocsparse_status rocsparse_csrilu0_dispatch(rocsparse_handle          handle,
                                    boost_tol_device_host,
                                    boost_val_device_host);
             }
+
+#else
+                hipLaunchKernelGGL((csrilu0_hybrid<CSRILU0_DIM, 64, 2,false>),
+                                   csrilu0_blocks,
+                                   csrilu0_threads,
+                                   0,
+                                   stream,
+                                   m,
+                                   csr_row_ptr,
+                                   csr_col_ind,
+                                   csr_val,
+                                   (rocsparse_int*)info->csrilu0_info->trm_diag_ind,
+                                   d_done_array,
+                                   (rocsparse_int*)info->csrilu0_info->row_map,
+                                   (rocsparse_int*)info->zero_pivot,
+                                   descr->base,
+                                   info->boost_enable,
+                                   boost_tol_device_host,
+                                   boost_val_device_host);
+#endif
         }
         else
         {


### PR DESCRIPTION
The code body for bisection and hash table csr ilu0 algorithms are extracted as lambda ( into files bisection_algorithm.h and hash_algorithm.h) then placed and used in hybrid version. The original call to use bisection is replaced by call to use hybrid version. 

The goal is to determine at execution time to use the faster hash algorithm for rows with small number of non-zeros but switch to bisection algorithm for only the  rows that contain a very high number of non-zeros (that exceed the size of hash table). 
