### PR TITLE
Updated HIP Bin prefix Path to rocm_path

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -28,7 +28,7 @@ find_package(Git REQUIRED)
 
 # Workaround until hcc & hip cmake modules fixes symlink logic in their config files.
 # (Thanks to rocBLAS devs for finding workaround for this problem!)
-list(APPEND CMAKE_PREFIX_PATH /opt/rocm/hip /opt/rocm)
+list(APPEND CMAKE_PREFIX_PATH /opt/rocm /opt/rocm/hip)
 
 # ROCm cmake package
 find_package(ROCM 0.7.3 QUIET CONFIG PATHS ${CMAKE_PREFIX_PATH})

--- a/toolchain-linux.cmake
+++ b/toolchain-linux.cmake
@@ -1,8 +1,8 @@
 
 if (DEFINED ENV{ROCM_PATH})
-  set(rocm_bin "$ENV{ROCM_PATH}/hip/bin")
+  set(rocm_bin "$ENV{ROCM_PATH}/bin")
 else()
-  set(rocm_bin "/opt/rocm/hip/bin")
+  set(rocm_bin "/opt/rocm/bin")
 endif()
 
 set(CMAKE_CXX_COMPILER "${rocm_bin}/hipcc")


### PR DESCRIPTION
resolves #___

Summary of proposed changes:
- Update HIP bin prefix path to rocm_path (rocm_path/bin will be used for hipcc as per the reorg structure)
-
-
