### PR TITLE
adding a script to build the executable convert. (#478)

### DIFF
--- a/scripts/performance/matrices/CMakeLists.txt
+++ b/scripts/performance/matrices/CMakeLists.txt
@@ -1,0 +1,2 @@
+project(convert)
+add_executable(convert convert.cpp)

--- a/scripts/performance/matrices/README
+++ b/scripts/performance/matrices/README
@@ -1,0 +1,2 @@
+
+Run the script build_convert.sh before running the scripts get_matrices.sh

--- a/scripts/performance/matrices/build_convert.sh
+++ b/scripts/performance/matrices/build_convert.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Author: Yvan Mokwinski
+
+mkdir build && cd build && cmake .. && make && cp ./convert .. && cd .. && rm -r build


### PR DESCRIPTION
resolves SWDEV-374810 and SWDEV-375165 

Summary of proposed changes:
- Adding a shell and CMake scripts to build the required executable to convert matrix files
