### PR TITLE
Use a kernel for small copies to device

### DIFF
--- a/library/src/include/utility.h
+++ b/library/src/include/utility.h
@@ -74,6 +74,21 @@ static inline void rocsparse_one(const rocsparse_handle handle, rocsparse_double
     *one = handle->zone;
 }
 
+template <typename T>
+ROCSPARSE_KERNEL __launch_bounds__(1) void rocsparse_assign_kernel(T* dest, T value) {
+    *dest = value;
+}
+
+// Set a single value on the device from the host asynchronously.
+template <typename T>
+static inline hipError_t rocsparse_assign_async(T* dest, T value, hipStream_t stream) {
+    // Use a kernel instead of memcpy, because memcpy is synchronous if the source is not in
+    // pinned memory.
+    // Memset lacks a 64bit option, but would involve a similar implicit kernel anyways.
+    hipLaunchKernelGGL(rocsparse_assign_kernel, dim3(1), dim3(1), 0, stream, dest, value);
+    return hipGetLastError();
+}
+
 // if trace logging is turned on with
 // (handle->layer_mode & rocsparse_layer_mode_log_trace) == true
 // then

--- a/library/src/level2/rocsparse_bsrsv_solve.cpp
+++ b/library/src/level2/rocsparse_bsrsv_solve.cpp
@@ -386,12 +386,9 @@ rocsparse_status rocsparse_bsrsv_solve_dispatch(rocsparse_handle          handle
     // If diag type is unit, re-initialize zero pivot to remove structural zeros
     if(descr->diag_type == rocsparse_diag_type_unit)
     {
-        static const rocsparse_int max = std::numeric_limits<rocsparse_int>::max();
-        RETURN_IF_HIP_ERROR(hipMemcpyAsync((rocsparse_int*)info->zero_pivot,
-                                           &max,
-                                           sizeof(rocsparse_int),
-                                           hipMemcpyHostToDevice,
-                                           stream));
+        RETURN_IF_HIP_ERROR(rocsparse_assign_async(static_cast<rocsparse_int*>(info->zero_pivot),
+                                                   std::numeric_limits<rocsparse_int>::max(),
+                                                   stream));
     }
 
     // Pointers to differentiate between transpose mode

--- a/library/src/level2/rocsparse_csritsv_solve.cpp
+++ b/library/src/level2/rocsparse_csritsv_solve.cpp
@@ -262,12 +262,10 @@ rocsparse_status rocsparse_csritsv_solve_template(rocsparse_handle          hand
         }
         else
         {
-            const rocsparse_int b = (rocsparse_int)descr->base;
-            RETURN_IF_HIP_ERROR(hipMemcpyAsync(info->zero_pivot,
-                                               &b,
-                                               sizeof(rocsparse_int),
-                                               hipMemcpyHostToDevice,
-                                               handle->stream));
+            RETURN_IF_HIP_ERROR(
+                rocsparse_assign_async(static_cast<rocsparse_int*>(info->zero_pivot),
+                                       (rocsparse_int)descr->base,
+                                       handle->stream));
             return rocsparse_status_success;
         }
     }

--- a/library/src/level2/rocsparse_csrsv_analysis.cpp
+++ b/library/src/level2/rocsparse_csrsv_analysis.cpp
@@ -185,9 +185,7 @@ rocsparse_status rocsparse_trm_analysis(rocsparse_handle          handle,
     RETURN_IF_HIP_ERROR(rocsparse_hipMallocAsync((void**)&info->row_map, sizeof(J) * m, stream));
 
     // Initialize zero pivot
-    static const J max = std::numeric_limits<J>::max();
-    RETURN_IF_HIP_ERROR(
-        hipMemcpyAsync(*zero_pivot, &max, sizeof(J), hipMemcpyHostToDevice, stream));
+    RETURN_IF_HIP_ERROR(rocsparse_assign_async(*zero_pivot, std::numeric_limits<J>::max(), stream));
 
     // Determine gcnArch and ASIC revision
     int gcnArch = handle->properties.gcnArch;

--- a/library/src/level2/rocsparse_csrsv_solve.cpp
+++ b/library/src/level2/rocsparse_csrsv_solve.cpp
@@ -116,9 +116,8 @@ rocsparse_status rocsparse_csrsv_solve_dispatch(rocsparse_handle          handle
     // If diag type is unit, re-initialize zero pivot to remove structural zeros
     if(descr->diag_type == rocsparse_diag_type_unit)
     {
-        static const J max = std::numeric_limits<J>::max();
-        RETURN_IF_HIP_ERROR(
-            hipMemcpyAsync(info->zero_pivot, &max, sizeof(J), hipMemcpyHostToDevice, stream));
+        RETURN_IF_HIP_ERROR(rocsparse_assign_async(
+            static_cast<J*>(info->zero_pivot), std::numeric_limits<J>::max(), stream));
     }
 
     // Pointers to differentiate between transpose mode

--- a/library/src/level3/rocsparse_csrsm.cpp
+++ b/library/src/level3/rocsparse_csrsm.cpp
@@ -667,9 +667,8 @@ rocsparse_status rocsparse_csrsm_solve_dispatch(rocsparse_handle          handle
     // If diag type is unit, re-initialize zero pivot to remove structural zeros
     if(descr->diag_type == rocsparse_diag_type_unit)
     {
-        static const J max = std::numeric_limits<J>::max();
-        RETURN_IF_HIP_ERROR(
-            hipMemcpyAsync(info->zero_pivot, &max, sizeof(J), hipMemcpyHostToDevice, stream));
+        RETURN_IF_HIP_ERROR(rocsparse_assign_async(
+            static_cast<J*>(info->zero_pivot), std::numeric_limits<J>::max(), stream));
     }
 
     // Leading dimension


### PR DESCRIPTION
Instead of `hipMemcpyAsync` use a simple kernel to set values in device memory.
`hipMemcpyAsync` blocks the host until the operations in the stream complete if the source is not pinned memory.
Using a kernel, the host doesn't have to wait. Note that an atomic write from the host wouldn't work as the copy has to happen after the current operations in the stream complete.

This matters in latency bound scenarios, for example compare the following traces from using rocsparse in petsc:
**Before this change:**
![before](https://user-images.githubusercontent.com/8176760/220077759-c9be6ddb-29aa-4269-aacf-4dbc6f345b61.png)
On the track named Hip activity, its visible that the host is blocked waiting for the copy to complete.
**After:**
![after](https://user-images.githubusercontent.com/8176760/220077813-77db0128-8e4c-4ffc-9964-753862c73247.png)

There are more similar copies in rocSPARSE, but in this PR I only propose this for the pivot copies, as a first step.
