### PR TITLE
Missing work from the client matrices dir options (#581)

### DIFF
--- a/clients/benchmarks/CMakeLists.txt
+++ b/clients/benchmarks/CMakeLists.txt
@@ -60,6 +60,7 @@ set(ROCSPARSE_CLIENTS_COMMON
   ../common/rocsparse_importer_rocsparseio.cpp
   ../common/rocsparse_importer_matrixmarket.cpp
   ../common/rocsparse_clients_envariables.cpp
+  ../common/rocsparse_clients_matrices_dir.cpp
 )
 
 

--- a/clients/benchmarks/rocsparse_arguments_config.cpp
+++ b/clients/benchmarks/rocsparse_arguments_config.cpp
@@ -1,6 +1,6 @@
 /*! \file */
 /* ************************************************************************
-* Copyright (C) 2021-2022 Advanced Micro Devices, Inc. All rights Reserved.
+* Copyright (C) 2021-2023 Advanced Micro Devices, Inc. All rights Reserved.
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
@@ -23,7 +23,9 @@
 * ************************************************************************ */
 
 #include "rocsparse_arguments_config.hpp"
+#include "rocsparse_clients_matrices_dir.hpp"
 #include "rocsparse_enum.hpp"
+
 rocsparse_arguments_config::rocsparse_arguments_config()
 {
     //
@@ -173,6 +175,10 @@ void rocsparse_arguments_config::set_description(options_description& desc)
     ("file",
      value<std::string>(&this->b_file)->default_value(""),
      "read from file with file extension detection. This will override parameters --rocsparseio,rocalution,mtx")
+
+    ("matrices-dir",
+     value<std::string>(&this->b_matrices_dir)->default_value(""),
+     "Specify the matrix source directory.")
 
     ("dimx",
      value<rocsparse_int>(&this->dimx)->default_value(0), "assemble "
@@ -502,6 +508,11 @@ int rocsparse_arguments_config::parse(int&argc,char**&argv, options_description&
     }
 #endif
 
+  if(this->b_matrices_dir != "")
+  {
+    rocsparse_clients_matrices_dir_set(this->b_matrices_dir.c_str());
+  }
+
   // rocALUTION parameter overrides filename parameter
   if(this->b_file != "")
   {
@@ -758,7 +769,13 @@ int rocsparse_arguments_config::parse_no_default(int&argc,char**&argv, options_d
   this->spmm_alg = (rocsparse_spmm_alg)this->b_spmm_alg;
   this->gtsv_interleaved_alg = (rocsparse_gtsv_interleaved_alg)this->b_gtsv_interleaved_alg;
 
+  if(this->b_matrices_dir != "")
+  {
+    rocsparse_clients_matrices_dir_set(this->b_matrices_dir.c_str());
+  }
+
   // rocALUTION parameter overrides filename parameter
+
   if(b_file != "")
   {
     strcpy(this->filename, b_file.c_str());

--- a/clients/benchmarks/rocsparse_arguments_config.hpp
+++ b/clients/benchmarks/rocsparse_arguments_config.hpp
@@ -1,6 +1,6 @@
 /*! \file */
 /* ************************************************************************
-* Copyright (C) 2021-2022 Advanced Micro Devices, Inc. All rights Reserved.
+* Copyright (C) 2021-2023 Advanced Micro Devices, Inc. All rights Reserved.
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
@@ -43,6 +43,7 @@ private:
     std::string   b_rocalution{};
     std::string   b_rocsparseio{};
     std::string   b_file{};
+    std::string   b_matrices_dir{};
     char          b_transA{};
     char          b_transB{};
     int           b_baseA{};

--- a/clients/common/rocsparse_clients_envariables.cpp
+++ b/clients/common/rocsparse_clients_envariables.cpp
@@ -132,7 +132,7 @@ public:
     //
     // Return the unique instance.
     //
-    static rocsparse_clients_envariables_impl& Instance();
+    static const rocsparse_clients_envariables_impl& Instance();
 
 private:
     ~rocsparse_clients_envariables_impl()                                         = default;
@@ -226,7 +226,7 @@ private:
     }
 };
 
-rocsparse_clients_envariables_impl& rocsparse_clients_envariables_impl::Instance()
+const rocsparse_clients_envariables_impl& rocsparse_clients_envariables_impl::Instance()
 {
     static rocsparse_clients_envariables_impl instance;
     return instance;

--- a/clients/common/rocsparse_clients_matrices_dir.cpp
+++ b/clients/common/rocsparse_clients_matrices_dir.cpp
@@ -1,0 +1,108 @@
+/* ************************************************************************
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * ************************************************************************ */
+
+#include "rocsparse_clients_matrices_dir.hpp"
+#include "rocsparse_clients_envariables.hpp"
+#include "utility.hpp"
+
+//
+//
+//
+struct clients_matrices_dir
+{
+private:
+    std::string m_path{};
+    std::string m_default_path{};
+    bool        m_is_defined{};
+    clients_matrices_dir()
+    {
+        m_is_defined = rocsparse_clients_envariables::is_defined(
+            rocsparse_clients_envariables::MATRICES_DIR);
+        if(m_is_defined)
+        {
+            m_path
+                = rocsparse_clients_envariables::get(rocsparse_clients_envariables::MATRICES_DIR);
+            if(m_path.size() > 0)
+            {
+                m_path += "/";
+            }
+        }
+        m_default_path = rocsparse_exepath();
+        m_default_path += "/../matrices/";
+    }
+
+public:
+    static clients_matrices_dir& instance()
+    {
+        static clients_matrices_dir self;
+        return self;
+    }
+    static const std::string& path(bool use_default)
+    {
+        const clients_matrices_dir& self = instance();
+        if(self.m_is_defined)
+        {
+            return self.m_path;
+        }
+        else
+        {
+            if(use_default)
+            {
+                return self.m_default_path;
+            }
+            else
+            {
+                return self.m_path;
+            }
+        }
+    }
+
+    static const std::string& default_path()
+    {
+        const clients_matrices_dir& self = instance();
+        return self.m_default_path;
+    }
+
+    static void set(const std::string& p)
+    {
+        clients_matrices_dir& self = instance();
+        self.m_is_defined          = true;
+        self.m_path                = p;
+    }
+};
+
+//
+//
+//
+const char* rocsparse_clients_matrices_dir_get(bool use_default_path)
+{
+    return clients_matrices_dir::path(use_default_path).c_str();
+}
+
+//
+//
+//
+void rocsparse_clients_matrices_dir_set(const char* path)
+{
+    clients_matrices_dir::set(std::string(path) + "/");
+}

--- a/clients/common/rocsparse_matrix_factory.cpp
+++ b/clients/common/rocsparse_matrix_factory.cpp
@@ -24,24 +24,27 @@
 
 #include "rocsparse_matrix_factory.hpp"
 #include "rocsparse_clients_envariables.hpp"
+#include "rocsparse_clients_matrices_dir.hpp"
 #include "rocsparse_init.hpp"
 
-static void get_matrix_full_filename(std::string&       full_filename_,
-                                     const std::string& filename_,
+static void get_matrix_full_filename(const Arguments&   arg_,
                                      const std::string& extension_,
-                                     const bool         timing_)
+                                     std::string&       full_filename_)
 {
-    const bool envar_is_defined
-        = rocsparse_clients_envariables::is_defined(rocsparse_clients_envariables::MATRICES_DIR);
-    std::string path = rocsparse_exepath() + "../matrices/";
-    if(envar_is_defined)
-    {
-        path = rocsparse_clients_envariables::get(rocsparse_clients_envariables::MATRICES_DIR);
-        path += "/";
-    }
 
-    full_filename_ = timing_ ? ((envar_is_defined) ? (path + filename_) : filename_)
-                             : (path + filename_ + extension_);
+    if(arg_.timing)
+    {
+        static constexpr bool use_default = false;
+        full_filename_                    = rocsparse_clients_matrices_dir_get(use_default);
+        full_filename_ += arg_.filename;
+    }
+    else
+    {
+        static constexpr bool use_default = true;
+        full_filename_                    = rocsparse_clients_matrices_dir_get(use_default);
+        full_filename_ += arg_.filename;
+        full_filename_ += extension_;
+    }
 }
 
 //
@@ -116,7 +119,7 @@ rocsparse_matrix_factory<T, I, J>::rocsparse_matrix_factory(const Arguments&    
     case rocsparse_matrix_file_rocalution:
     {
         std::string full_filename;
-        get_matrix_full_filename(full_filename, arg.filename, ".csr", arg.timing);
+        get_matrix_full_filename(arg, ".csr", full_filename);
 
         this->m_instance
             = new rocsparse_matrix_factory_rocalution<T, I, J>(full_filename.c_str(), to_int);
@@ -126,7 +129,7 @@ rocsparse_matrix_factory<T, I, J>::rocsparse_matrix_factory(const Arguments&    
     case rocsparse_matrix_file_rocsparseio:
     {
         std::string full_filename;
-        get_matrix_full_filename(full_filename, arg.filename, ".bin", arg.timing);
+        get_matrix_full_filename(arg, ".bin", full_filename);
         this->m_instance
             = new rocsparse_matrix_factory_rocsparseio<T, I, J>(full_filename.c_str(), to_int);
         break;
@@ -135,7 +138,7 @@ rocsparse_matrix_factory<T, I, J>::rocsparse_matrix_factory(const Arguments&    
     case rocsparse_matrix_file_mtx:
     {
         std::string full_filename;
-        get_matrix_full_filename(full_filename, arg.filename, ".mtx", arg.timing);
+        get_matrix_full_filename(arg, ".mtx", full_filename);
         this->m_instance = new rocsparse_matrix_factory_mtx<T, I, J>(full_filename.c_str());
         break;
     }

--- a/clients/common/rocsparse_parse_data.cpp
+++ b/clients/common/rocsparse_parse_data.cpp
@@ -23,6 +23,7 @@
  * ************************************************************************ */
 
 #include "rocsparse_parse_data.hpp"
+#include "rocsparse_clients_matrices_dir.hpp"
 #include "rocsparse_data.hpp"
 #include "utility.hpp"
 
@@ -96,7 +97,7 @@ static std::string rocsparse_parse_yaml(const std::string& yaml)
 #endif
 }
 
-// Parse --data and --yaml command-line arguments
+// Parse --data and --yaml command-line arguments, -- matrices-dir and optionally memstat-report
 bool rocsparse_parse_data(int& argc, char** argv, const std::string& default_file)
 {
     std::string filename;
@@ -135,15 +136,26 @@ bool rocsparse_parse_data(int& argc, char** argv, const std::string& default_fil
             memory_report_filename = argv[++i];
         }
 #endif
+        else if(!strcmp(argv[i], "--matrices-dir"))
+        {
+            if(!argv[i + 1] || !argv[i + 1][0])
+            {
+                std::cerr << "The " << argv[i] << " option requires an argument" << std::endl;
+                exit(EXIT_FAILURE);
+            }
+            rocsparse_clients_matrices_dir_set(argv[++i]);
+        }
         else
         {
             *argv_p++ = argv[i];
             if(!help && (!strcmp(argv[i], "-h") || !strcmp(argv[i], "--help")))
             {
                 help = true;
-                std::cout << "\n"
-                          << argv[0] << " [ --data <path> | --yaml <path> ] <options> ...\n"
-                          << std::endl;
+                std::cout
+                    << "\n"
+                    << argv[0]
+                    << " [ --data <path> | --yaml <path> ] [--matrices-dir <path>] <options> ...\n"
+                    << std::endl;
 
                 std::cout << "" << std::endl;
                 std::cout << "Specific environment variables:" << std::endl;

--- a/clients/include/rocsparse_clients_matrices_dir.hpp
+++ b/clients/include/rocsparse_clients_matrices_dir.hpp
@@ -1,6 +1,6 @@
 /*! \file */
 /* ************************************************************************
- * Copyright (C) 2019-2023 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,8 +22,7 @@
  *
  * ************************************************************************ */
 
-#include "test.hpp"
+#pragma once
 
-#include "testing_csricsv.hpp"
-
-TEST_ROUTINE(csricsv, extra, arg.apol, arg.spol, arg.baseA, arg.matrix);
+const char* rocsparse_clients_matrices_dir_get(bool use_default_path);
+void        rocsparse_clients_matrices_dir_set(const char* path);

--- a/clients/tests/CMakeLists.txt
+++ b/clients/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ########################################################################
-# Copyright (C) 2018-2022 Advanced Micro Devices, Inc. All rights Reserved.
+# Copyright (C) 2018-2023 Advanced Micro Devices, Inc. All rights Reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -330,6 +330,7 @@ set(ROCSPARSE_CLIENTS_COMMON
   ../common/rocsparse_importer_rocsparseio.cpp
   ../common/rocsparse_importer_matrixmarket.cpp
   ../common/rocsparse_clients_envariables.cpp
+  ../common/rocsparse_clients_matrices_dir.cpp
   )
 
 add_executable(rocsparse-test rocsparse_test_main.cpp ${ROCSPARSE_TEST_SOURCES} ${ROCSPARSE_CLIENTS_COMMON} ${ROCSPARSE_CLIENTS_TESTINGS})

--- a/clients/tests/rocsparse_test_main.cpp
+++ b/clients/tests/rocsparse_test_main.cpp
@@ -1,6 +1,6 @@
 /*! \file */
 /* ************************************************************************
- * Copyright (C) 2019-2022 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2019-2023 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -179,6 +179,14 @@ int main(int argc, char** argv)
         if(strcmp(argv[i], "--device") == 0 && argc > i + 1)
         {
             dev = atoi(argv[i + 1]);
+        }
+        else if(strcmp(argv[i], "--version") == 0)
+        {
+            // Print version and exit, if requested
+            std::cout << "rocSPARSE version: " << ver / 100000 << "." << ver / 100 % 1000 << "."
+                      << ver % 100 << "-" << rev << std::endl;
+
+            return 0;
         }
     }
 

--- a/clients/tests/test_csrilusv.cpp
+++ b/clients/tests/test_csrilusv.cpp
@@ -1,6 +1,6 @@
 /*! \file */
 /* ************************************************************************
- * Copyright (C) 2019-2022 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2019-2023 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -26,4 +26,4 @@
 
 #include "testing_csrilusv.hpp"
 
-TEST_ROUTINE(csrilusv, extra, arg.apol, arg.spol, arg.baseA, arg.matrix, arg.filename);
+TEST_ROUTINE(csrilusv, extra, arg.apol, arg.spol, arg.baseA, arg.matrix);

--- a/scripts/performance/dbsrmv.sh
+++ b/scripts/performance/dbsrmv.sh
@@ -8,6 +8,7 @@ function display_help()
     echo "    [-h|--help] prints this help message"
     echo "    [-d|--device] select device"
     echo "    [-p|--path] path to rocsparse-bench"
+    echo "    [-d|--matrices-dir] directory of matrix files, this option discards the environment variable MATRICES_DIR. "
     echo "    [-b|--blockdim] BSR block dimension"
 }
 
@@ -36,10 +37,19 @@ if [[ $? -ne 0 ]]; then
     exit 1
 fi
 
+if [[ ( ${MATRICES_DIR} == "" ) ]];then
+    matrices_dir=./matrices
+else
+    matrices_dir=${MATRICES_DIR}
+fi
+
 eval set -- "${GETOPT_PARSE}"
 
 while true; do
     case "${1}" in
+        -d|--matrices-dir)
+            matrices_dir=${2}
+            shift 2 ;;
         -h|--help)
             display_help
             exit 0
@@ -74,7 +84,10 @@ fi
 logname=dbsrmv_$(date +'%Y%m%d%H%M%S').log
 truncate -s 0 $logname
 
+which=`ls $matrices_dir/*.csr`
+filenames=`for i in $which;do basename $i;done`
+
 # Run bsrmv for all matrices available
-for filename in ./matrices/*.csr; do
-    $bench -f bsrmv --precision d --device $dev --blockdim $blockdim --alpha 1 --beta 0 --iters 1000 --rocalution $filename 2>&1 | tee -a $logname
+for filename in $filenames; do
+    $bench --matrices-dir $matrices_dir -f bsrmv --precision d --device $dev --blockdim $blockdim --alpha 1 --beta 0 --iters 1000 --rocalution $filename 2>&1 | tee -a $logname
 done

--- a/scripts/performance/dcoomv.sh
+++ b/scripts/performance/dcoomv.sh
@@ -8,6 +8,7 @@ function display_help()
     echo "    [-h|--help] prints this help message"
     echo "    [-d|--device] select device"
     echo "    [-p|--path] path to rocsparse-bench"
+    echo "    [-d|--matrices-dir] directory of matrix files, this option discards the environment variable MATRICES_DIR. "
 }
 
 # Check if getopt command is installed
@@ -34,10 +35,19 @@ if [[ $? -ne 0 ]]; then
     exit 1
 fi
 
+if [[ ( ${MATRICES_DIR} == "" ) ]];then
+    matrices_dir=./matrices
+else
+    matrices_dir=${MATRICES_DIR}
+fi
+
 eval set -- "${GETOPT_PARSE}"
 
 while true; do
     case "${1}" in
+        -d|--matrices-dir)
+            matrices_dir=${2}
+            shift 2 ;;
         -h|--help)
             display_help
             exit 0
@@ -69,7 +79,10 @@ fi
 logname=dcoomv_$(date +'%Y%m%d%H%M%S').log
 truncate -s 0 $logname
 
+which=`ls $matrices_dir/*.csr`
+filenames=`for i in $which;do basename $i;done`
+
 # Run coomv for all matrices available
-for filename in ./matrices/*.csr; do
-    $bench -f coomv --spmv_alg 5 --precision d --device $dev --alpha 1 --beta 0 --iters 1000 --rocalution $filename 2>&1 | tee -a $logname
+for filename in $filenames; do
+    $bench --matrices-dir $matrices_dir -f coomv --spmv_alg 5 --precision d --device $dev --alpha 1 --beta 0 --iters 1000 --rocalution $filename 2>&1 | tee -a $logname
 done

--- a/scripts/performance/dcsrgeam.sh
+++ b/scripts/performance/dcsrgeam.sh
@@ -8,6 +8,7 @@ function display_help()
     echo "    [-h|--help] prints this help message"
     echo "    [-d|--device] select device"
     echo "    [-p|--path] path to rocsparse-bench"
+    echo "    [-d|--matrices-dir] directory of matrix files, this option discards the environment variable MATRICES_DIR. "
     echo "    [-n|--sizen] number of dense columns"
 }
 
@@ -36,10 +37,19 @@ if [[ $? -ne 0 ]]; then
     exit 1
 fi
 
+if [[ ( ${MATRICES_DIR} == "" ) ]];then
+    matrices_dir=./matrices
+else
+    matrices_dir=${MATRICES_DIR}
+fi
+
 eval set -- "${GETOPT_PARSE}"
 
 while true; do
     case "${1}" in
+        -d|--matrices-dir)
+            matrices_dir=${2}
+            shift 2 ;;
         -h|--help)
             display_help
             exit 0
@@ -73,8 +83,10 @@ fi
 # Generate logfile name
 logname=dcsrgeam_$(date +'%Y%m%d%H%M%S').log
 truncate -s 0 $logname
+which=`ls $matrices_dir/*.csr`
+filenames=`for i in $which;do basename $i;done`
 
 # Run csrgeam for all matrices available
-for filename in ./matrices/*.csr; do
-    $bench -f csrgeam --precision d --device $dev --alpha 1 --iters 200 --rocalution $filename 2>&1 | tee -a $logname
+for filename in $filenames; do
+    $bench --matrices-dir $matrices_dir -f csrgeam --precision d --device $dev --alpha 1 --iters 200 --rocalution $filename 2>&1 | tee -a $logname
 done

--- a/scripts/performance/dcsrgemm.sh
+++ b/scripts/performance/dcsrgemm.sh
@@ -8,6 +8,7 @@ function display_help()
     echo "    [-h|--help] prints this help message"
     echo "    [-d|--device] select device"
     echo "    [-p|--path] path to rocsparse-bench"
+    echo "    [-d|--matrices-dir] directory of matrix files, this option discards the environment variable MATRICES_DIR. "
     echo "    [-n|--sizen] number of dense columns"
 }
 
@@ -36,10 +37,19 @@ if [[ $? -ne 0 ]]; then
     exit 1
 fi
 
+if [[ ( ${MATRICES_DIR} == "" ) ]];then
+    matrices_dir=./matrices
+else
+    matrices_dir=${MATRICES_DIR}
+fi
+
 eval set -- "${GETOPT_PARSE}"
 
 while true; do
     case "${1}" in
+        -d|--matrices-dir)
+            matrices_dir=${2}
+            shift 2 ;;
         -h|--help)
             display_help
             exit 0
@@ -73,8 +83,10 @@ fi
 # Generate logfile name
 logname=dcsrgemm_$(date +'%Y%m%d%H%M%S').log
 truncate -s 0 $logname
+which=`ls $matrices_dir/*.csr`
+filenames=`for i in $which;do basename $i;done`
 
 # Run csrgemm for all matrices available
-for filename in ./matrices/*.csr; do
-    $bench -f csrgemm --precision d --device $dev --sizen $sizen --alpha 1 --iters 200 --rocalution $filename 2>&1 | tee -a $logname
+for filename in $filenames; do
+    $bench --matrices-dir $matrices_dir -f csrgemm --precision d --device $dev --sizen $sizen --alpha 1 --iters 200 --rocalution $filename 2>&1 | tee -a $logname
 done

--- a/scripts/performance/dcsrmm.sh
+++ b/scripts/performance/dcsrmm.sh
@@ -8,6 +8,7 @@ function display_help()
     echo "    [-h|--help] prints this help message"
     echo "    [-d|--device] select device"
     echo "    [-p|--path] path to rocsparse-bench"
+    echo "    [-d|--matrices-dir] directory of matrix files, this option discards the environment variable MATRICES_DIR. "
     echo "    [-n|--sizen] number of dense columns"
 }
 
@@ -36,10 +37,19 @@ if [[ $? -ne 0 ]]; then
     exit 1
 fi
 
+if [[ ( ${MATRICES_DIR} == "" ) ]];then
+    matrices_dir=./matrices
+else
+    matrices_dir=${MATRICES_DIR}
+fi
+
 eval set -- "${GETOPT_PARSE}"
 
 while true; do
     case "${1}" in
+        -d|--matrices-dir)
+            matrices_dir=${2}
+            shift 2 ;;
         -h|--help)
             display_help
             exit 0
@@ -74,7 +84,9 @@ fi
 logname=dcsrmm_$(date +'%Y%m%d%H%M%S').log
 truncate -s 0 $logname
 
+which=`ls $matrices_dir/*.csr`
+filenames=`for i in $which;do basename $i;done`
 # Run csrmm for all matrices available
-for filename in ./matrices/*.csr; do
-    $bench -f csrmm --precision d --device $dev --sizen $sizen --alpha 1 --beta 0 --iters 200 --rocalution $filename 2>&1 | tee -a $logname
+for filename in $filenames; do
+    $bench --matrices-dir $matrices_dir -f csrmm --precision d --device $dev --sizen $sizen --alpha 1 --beta 0 --iters 200 --rocalution $filename 2>&1 | tee -a $logname
 done

--- a/scripts/performance/dcsrmmt.sh
+++ b/scripts/performance/dcsrmmt.sh
@@ -8,6 +8,7 @@ function display_help()
     echo "    [-h|--help] prints this help message"
     echo "    [-d|--device] select device"
     echo "    [-p|--path] path to rocsparse-bench"
+    echo "    [-d|--matrices-dir] directory of matrix files, this option discards the environment variable MATRICES_DIR. "
     echo "    [-n|--sizen] number of dense columns"
 }
 
@@ -36,10 +37,19 @@ if [[ $? -ne 0 ]]; then
     exit 1
 fi
 
+if [[ ( ${MATRICES_DIR} == "" ) ]];then
+    matrices_dir=./matrices
+else
+    matrices_dir=${MATRICES_DIR}
+fi
+
 eval set -- "${GETOPT_PARSE}"
 
 while true; do
     case "${1}" in
+        -d|--matrices-dir)
+            matrices_dir=${2}
+            shift 2 ;;
         -h|--help)
             display_help
             exit 0
@@ -74,7 +84,10 @@ fi
 logname=dcsrmm_$(date +'%Y%m%d%H%M%S').log
 truncate -s 0 $logname
 
+which=`ls $matrices_dir/*.csr`
+filenames=`for i in $which;do basename $i;done`
+
 # Run csrmm for all matrices available
-for filename in ./matrices/*.csr; do
-    $bench -f csrmm --precision d --device $dev --sizen $sizen --order 0 --transposeB T --alpha 1 --beta 0 --iters 200 --rocalution $filename 2>&1 | tee -a $logname
+for filename in $filenames; do
+    $bench --matrices-dir $matrices_dir -f csrmm --precision d --device $dev --sizen $sizen --order 0 --transposeB T --alpha 1 --beta 0 --iters 200 --rocalution $filename 2>&1 | tee -a $logname
 done

--- a/scripts/performance/dcsrmv.sh
+++ b/scripts/performance/dcsrmv.sh
@@ -8,6 +8,7 @@ function display_help()
     echo "    [-h|--help] prints this help message"
     echo "    [-d|--device] select device"
     echo "    [-p|--path] path to rocsparse-bench"
+    echo "    [-d|--matrices-dir] directory of matrix files, this option discards the environment variable MATRICES_DIR. "
 }
 
 # Check if getopt command is installed
@@ -34,10 +35,19 @@ if [[ $? -ne 0 ]]; then
     exit 1
 fi
 
+if [[ ( ${MATRICES_DIR} == "" ) ]];then
+    matrices_dir=./matrices
+else
+    matrices_dir=${MATRICES_DIR}
+fi
+
 eval set -- "${GETOPT_PARSE}"
 
 while true; do
     case "${1}" in
+        -d|--matrices-dir)
+            matrices_dir=${2}
+            shift 2 ;;
         -h|--help)
             display_help
             exit 0
@@ -69,7 +79,11 @@ fi
 logname=dcsrmv_$(date +'%Y%m%d%H%M%S').log
 truncate -s 0 $logname
 
+
+which=`ls $matrices_dir/*.csr`
+filenames=`for i in $which;do basename $i;done`
+
 # Run csrmv for all matrices available
-for filename in ./matrices/*.csr; do
-    $bench -f csrmv --precision d --device $dev --alpha 1 --beta 0 --iters 1000 --rocalution $filename 2>&1 | tee -a $logname
+for filename in $filenames; do
+    $bench --matrices-dir $matrices_dir -f csrmv --precision d --device $dev --alpha 1 --beta 0 --iters 1000 --rocalution $filename 2>&1 | tee -a $logname
 done

--- a/scripts/performance/dcsrsv.sh
+++ b/scripts/performance/dcsrsv.sh
@@ -8,6 +8,7 @@ function display_help()
     echo "    [-h|--help] prints this help message"
     echo "    [-d|--device] select device"
     echo "    [-p|--path] path to rocsparse-bench"
+    echo "    [-d|--matrices-dir] directory of matrix files, this option discards the environment variable MATRICES_DIR. "
 }
 
 # Check if getopt command is installed
@@ -34,10 +35,19 @@ if [[ $? -ne 0 ]]; then
     exit 1
 fi
 
+if [[ ( ${MATRICES_DIR} == "" ) ]];then
+    matrices_dir=./matrices
+else
+    matrices_dir=${MATRICES_DIR}
+fi
+
 eval set -- "${GETOPT_PARSE}"
 
 while true; do
     case "${1}" in
+        -d|--matrices-dir)
+            matrices_dir=${2}
+            shift 2 ;;
         -h|--help)
             display_help
             exit 0
@@ -69,7 +79,10 @@ fi
 logname=dcsrsv_$(date +'%Y%m%d%H%M%S').log
 truncate -s 0 $logname
 
+which=`ls $matrices_dir/*.csr`
+filenames=`for i in $which;do basename $i;done`
+
 # Run csrsv for all matrices available
-for filename in ./matrices/*.csr; do
-    $bench -f csrsv --precision d --device $dev --alpha 1 --iters 1000 --rocalution $filename 2>&1 | tee -a $logname
+for filename in $filenames; do
+    $bench --matrices-dir $matrices_dir -f csrsv --precision d --device $dev --alpha 1 --iters 1000 --rocalution $filename 2>&1 | tee -a $logname
 done

--- a/scripts/performance/dellmv.sh
+++ b/scripts/performance/dellmv.sh
@@ -8,6 +8,7 @@ function display_help()
     echo "    [-h|--help] prints this help message"
     echo "    [-d|--device] select device"
     echo "    [-p|--path] path to rocsparse-bench"
+    echo "    [-d|--matrices-dir] directory of matrix files, this option discards the environment variable MATRICES_DIR. "
 }
 
 # Check if getopt command is installed
@@ -34,10 +35,19 @@ if [[ $? -ne 0 ]]; then
     exit 1
 fi
 
+if [[ ( ${MATRICES_DIR} == "" ) ]];then
+    matrices_dir=./matrices
+else
+    matrices_dir=${MATRICES_DIR}
+fi
+
 eval set -- "${GETOPT_PARSE}"
 
 while true; do
     case "${1}" in
+        -d|--matrices-dir)
+            matrices_dir=${2}
+            shift 2 ;;
         -h|--help)
             display_help
             exit 0
@@ -69,7 +79,10 @@ fi
 logname=dellmv_$(date +'%Y%m%d%H%M%S').log
 truncate -s 0 $logname
 
+which=`ls $matrices_dir/*.csr`
+filenames=`for i in $which;do basename $i;done`
+
 # Run ellmv for all matrices available
-for filename in ./matrices/*.csr; do
-    $bench -f ellmv --precision d --device $dev --alpha 1 --beta 0 --iters 1000 --rocalution $filename 2>&1 | tee -a $logname
+for filename in $filenames; do
+    $bench --matrices-dir $matrices_dir -f ellmv --precision d --device $dev --alpha 1 --beta 0 --iters 1000 --rocalution $filename 2>&1 | tee -a $logname
 done

--- a/scripts/performance/scoomv.sh
+++ b/scripts/performance/scoomv.sh
@@ -8,6 +8,7 @@ function display_help()
     echo "    [-h|--help] prints this help message"
     echo "    [-d|--device] select device"
     echo "    [-p|--path] path to rocsparse-bench"
+    echo "    [-d|--matrices-dir] directory of matrix files, this option discards the environment variable MATRICES_DIR. "
 }
 
 # Check if getopt command is installed
@@ -34,10 +35,19 @@ if [[ $? -ne 0 ]]; then
     exit 1
 fi
 
+if [[ ( ${MATRICES_DIR} == "" ) ]];then
+    matrices_dir=./matrices
+else
+    matrices_dir=${MATRICES_DIR}
+fi
+
 eval set -- "${GETOPT_PARSE}"
 
 while true; do
     case "${1}" in
+        -d|--matrices-dir)
+            matrices_dir=${2}
+            shift 2 ;;
         -h|--help)
             display_help
             exit 0
@@ -69,7 +79,9 @@ fi
 logname=scoomv_$(date +'%Y%m%d%H%M%S').log
 truncate -s 0 $logname
 
+which=`ls $matrices_dir/*.csr`
+filenames=`for i in $which;do basename $i;done`
 # Run coomv for all matrices available
-for filename in ./matrices/*.csr; do
-    $bench -f coomv --spmv_alg 5 --precision s --device $dev --alpha 1 --beta 0 --iters 1000 --rocalution $filename 2>&1 | tee -a $logname
+for filename in $filenames; do
+    $bench --matrices-dir $matrices_dir -f coomv --spmv_alg 5 --precision s --device $dev --alpha 1 --beta 0 --iters 1000 --rocalution $filename 2>&1 | tee -a $logname
 done

--- a/scripts/performance/scsrgeam.sh
+++ b/scripts/performance/scsrgeam.sh
@@ -8,6 +8,7 @@ function display_help()
     echo "    [-h|--help] prints this help message"
     echo "    [-d|--device] select device"
     echo "    [-p|--path] path to rocsparse-bench"
+    echo "    [-d|--matrices-dir] directory of matrix files, this option discards the environment variable MATRICES_DIR. "
     echo "    [-n|--sizen] number of dense columns"
 }
 
@@ -36,10 +37,19 @@ if [[ $? -ne 0 ]]; then
     exit 1
 fi
 
+if [[ ( ${MATRICES_DIR} == "" ) ]];then
+    matrices_dir=./matrices
+else
+    matrices_dir=${MATRICES_DIR}
+fi
+
 eval set -- "${GETOPT_PARSE}"
 
 while true; do
     case "${1}" in
+        -d|--matrices-dir)
+            matrices_dir=${2}
+            shift 2 ;;
         -h|--help)
             display_help
             exit 0
@@ -74,7 +84,9 @@ fi
 logname=scsrgeam_$(date +'%Y%m%d%H%M%S').log
 truncate -s 0 $logname
 
+which=`ls $matrices_dir/*.csr`
+filenames=`for i in $which;do basename $i;done`
 # Run csrgeam for all matrices available
-for filename in ./matrices/*.csr; do
-    $bench -f csrgeam --precision s --device $dev --alpha 1 --iters 200 --rocalution $filename 2>&1 | tee -a $logname
+for filename in $filenames; do
+    $bench --matrices-dir $matrices_dir -f csrgeam --precision s --device $dev --alpha 1 --iters 200 --rocalution $filename 2>&1 | tee -a $logname
 done

--- a/scripts/performance/scsrgemm.sh
+++ b/scripts/performance/scsrgemm.sh
@@ -8,6 +8,7 @@ function display_help()
     echo "    [-h|--help] prints this help message"
     echo "    [-d|--device] select device"
     echo "    [-p|--path] path to rocsparse-bench"
+    echo "    [-d|--matrices-dir] directory of matrix files, this option discards the environment variable MATRICES_DIR. "
     echo "    [-n|--sizen] number of dense columns"
 }
 
@@ -36,10 +37,19 @@ if [[ $? -ne 0 ]]; then
     exit 1
 fi
 
+if [[ ( ${MATRICES_DIR} == "" ) ]];then
+    matrices_dir=./matrices
+else
+    matrices_dir=${MATRICES_DIR}
+fi
+
 eval set -- "${GETOPT_PARSE}"
 
 while true; do
     case "${1}" in
+        -d|--matrices-dir)
+            matrices_dir=${2}
+            shift 2 ;;
         -h|--help)
             display_help
             exit 0
@@ -74,7 +84,9 @@ fi
 logname=scsrgemm_$(date +'%Y%m%d%H%M%S').log
 truncate -s 0 $logname
 
+which=`ls $matrices_dir/*.csr`
+filenames=`for i in $which;do basename $i;done`
 # Run csrgemm for all matrices available
-for filename in ./matrices/*.csr; do
-    $bench -f csrgemm --precision s --device $dev --sizen $sizen --alpha 1 --iters 200 --rocalution $filename 2>&1 | tee -a $logname
+for filename in $filenames; do
+    $bench --matrices-dir $matrices_dir -f csrgemm --precision s --device $dev --sizen $sizen --alpha 1 --iters 200 --rocalution $filename 2>&1 | tee -a $logname
 done

--- a/scripts/performance/scsrmm.sh
+++ b/scripts/performance/scsrmm.sh
@@ -8,6 +8,7 @@ function display_help()
     echo "    [-h|--help] prints this help message"
     echo "    [-d|--device] select device"
     echo "    [-p|--path] path to rocsparse-bench"
+    echo "    [-d|--matrices-dir] directory of matrix files, this option discards the environment variable MATRICES_DIR. "
     echo "    [-n|--sizen] number of dense columns"
 }
 
@@ -36,10 +37,20 @@ if [[ $? -ne 0 ]]; then
     exit 1
 fi
 
+
+if [[ ( ${MATRICES_DIR} == "" ) ]];then
+    matrices_dir=./matrices
+else
+    matrices_dir=${MATRICES_DIR}
+fi
+
 eval set -- "${GETOPT_PARSE}"
 
 while true; do
     case "${1}" in
+        -d|--matrices-dir)
+            matrices_dir=${2}
+            shift 2 ;;
         -h|--help)
             display_help
             exit 0
@@ -74,7 +85,9 @@ fi
 logname=scsrmm_$(date +'%Y%m%d%H%M%S').log
 truncate -s 0 $logname
 
+which=`ls $matrices_dir/*.csr`
+filenames=`for i in $which;do basename $i;done`
 # Run csrmm for all matrices available
-for filename in ./matrices/*.csr; do
-    $bench -f csrmm --precision s --device $dev --sizen $sizen --alpha 1 --beta 0 --iters 200 --rocalution $filename 2>&1 | tee -a $logname
+for filename in $filenames; do
+    $bench --matrices-dir $matrices_dir -f csrmm --precision s --device $dev --sizen $sizen --alpha 1 --beta 0 --iters 200 --rocalution $filename 2>&1 | tee -a $logname
 done

--- a/scripts/performance/scsrmmt.sh
+++ b/scripts/performance/scsrmmt.sh
@@ -8,6 +8,7 @@ function display_help()
     echo "    [-h|--help] prints this help message"
     echo "    [-d|--device] select device"
     echo "    [-p|--path] path to rocsparse-bench"
+    echo "    [-d|--matrices-dir] directory of matrix files, this option discards the environment variable MATRICES_DIR. "
     echo "    [-n|--sizen] number of dense columns"
 }
 
@@ -36,10 +37,19 @@ if [[ $? -ne 0 ]]; then
     exit 1
 fi
 
+if [[ ( ${MATRICES_DIR} == "" ) ]];then
+    matrices_dir=./matrices
+else
+    matrices_dir=${MATRICES_DIR}
+fi
+
 eval set -- "${GETOPT_PARSE}"
 
 while true; do
     case "${1}" in
+        -d|--matrices-dir)
+            matrices_dir=${2}
+            shift 2 ;;
         -h|--help)
             display_help
             exit 0
@@ -73,8 +83,9 @@ fi
 # Generate logfile name
 logname=scsrmm_$(date +'%Y%m%d%H%M%S').log
 truncate -s 0 $logname
-
+which=`ls $matrices_dir/*.csr`
+filenames=`for i in $which;do basename $i;done`
 # Run csrmm for all matrices available
-for filename in ./matrices/*.csr; do
-    $bench -f csrmm --precision s --device $dev --sizen $sizen --transposeB T --alpha 1 --beta 0 --iters 200 --rocalution $filename 2>&1 | tee -a $logname
+for filename in $filenames; do
+    $bench --matrices-dir $matrices_dir -f csrmm --precision s --device $dev --sizen $sizen --transposeB T --alpha 1 --beta 0 --iters 200 --rocalution $filename 2>&1 | tee -a $logname
 done

--- a/scripts/performance/scsrmv.sh
+++ b/scripts/performance/scsrmv.sh
@@ -8,6 +8,7 @@ function display_help()
     echo "    [-h|--help] prints this help message"
     echo "    [-d|--device] select device"
     echo "    [-p|--path] path to rocsparse-bench"
+    echo "    [-d|--matrices-dir] directory of matrix files, this option discards the environment variable MATRICES_DIR. "
 }
 
 # Check if getopt command is installed
@@ -34,10 +35,19 @@ if [[ $? -ne 0 ]]; then
     exit 1
 fi
 
+if [[ ( ${MATRICES_DIR} == "" ) ]];then
+    matrices_dir=./matrices
+else
+    matrices_dir=${MATRICES_DIR}
+fi
+
 eval set -- "${GETOPT_PARSE}"
 
 while true; do
     case "${1}" in
+        -d|--matrices-dir)
+            matrices_dir=${2}
+            shift 2 ;;
         -h|--help)
             display_help
             exit 0
@@ -47,6 +57,9 @@ while true; do
             shift 2 ;;
         -p|--path)
             path=${2}
+            shift 2 ;;
+        -d|--matrices-dir)
+            matrices_dir=${2}
             shift 2 ;;
         --) shift ; break ;;
         *)  echo "Unexpected command line parameter received; aborting";
@@ -69,7 +82,9 @@ fi
 logname=scsrmv_$(date +'%Y%m%d%H%M%S').log
 truncate -s 0 $logname
 
+which=`ls $matrices_dir/*.csr`
+filenames=`for i in $which;do basename $i;done`
 # Run csrmv for all matrices available
-for filename in ./matrices/*.csr; do
-    $bench -f csrmv --precision s --device $dev --alpha 1 --beta 0 --iters 1000 --rocalution $filename 2>&1 | tee -a $logname
+for filename in $filenames; do
+    $bench --matrices-dir $matrices_dir -f csrmv --precision s --device $dev --alpha 1 --beta 0 --iters 1000 --rocalution $filename 2>&1 | tee -a $logname
 done

--- a/scripts/performance/scsrsv.sh
+++ b/scripts/performance/scsrsv.sh
@@ -8,6 +8,7 @@ function display_help()
     echo "    [-h|--help] prints this help message"
     echo "    [-d|--device] select device"
     echo "    [-p|--path] path to rocsparse-bench"
+    echo "    [-d|--matrices-dir] directory of matrix files, this option discards the environment variable MATRICES_DIR. "
 }
 
 # Check if getopt command is installed
@@ -34,10 +35,20 @@ if [[ $? -ne 0 ]]; then
     exit 1
 fi
 
+
+if [[ ( ${MATRICES_DIR} == "" ) ]];then
+    matrices_dir=./matrices
+else
+    matrices_dir=${MATRICES_DIR}
+fi
+
 eval set -- "${GETOPT_PARSE}"
 
 while true; do
     case "${1}" in
+        -d|--matrices-dir)
+            matrices_dir=${2}
+            shift 2 ;;
         -h|--help)
             display_help
             exit 0
@@ -68,8 +79,9 @@ fi
 # Generate logfile name
 logname=scsrsv_$(date +'%Y%m%d%H%M%S').log
 truncate -s 0 $logname
-
+which=`ls $matrices_dir/*.csr`
+filenames=`for i in $which;do basename $i;done`
 # Run csrsv for all matrices available
-for filename in ./matrices/*.csr; do
-    $bench -f csrsv --precision s --device $dev --alpha 1 --iters 1000 --rocalution $filename 2>&1 | tee -a $logname
+for filename in $filenames; do
+    $bench --matrices-dir $matrices_dir -f csrsv --precision s --device $dev --alpha 1 --iters 1000 --rocalution $filename 2>&1 | tee -a $logname
 done

--- a/scripts/performance/sellmv.sh
+++ b/scripts/performance/sellmv.sh
@@ -8,6 +8,7 @@ function display_help()
     echo "    [-h|--help] prints this help message"
     echo "    [-d|--device] select device"
     echo "    [-p|--path] path to rocsparse-bench"
+    echo "    [-d|--matrices-dir] directory of matrix files, this option discards the environment variable MATRICES_DIR. "
 }
 
 # Check if getopt command is installed
@@ -34,10 +35,19 @@ if [[ $? -ne 0 ]]; then
     exit 1
 fi
 
+if [[ ( ${MATRICES_DIR} == "" ) ]];then
+    matrices_dir=./matrices
+else
+    matrices_dir=${MATRICES_DIR}
+fi
+
 eval set -- "${GETOPT_PARSE}"
 
 while true; do
     case "${1}" in
+        -d|--matrices-dir)
+            matrices_dir=${2}
+            shift 2 ;;
         -h|--help)
             display_help
             exit 0
@@ -69,7 +79,9 @@ fi
 logname=sellmv_$(date +'%Y%m%d%H%M%S').log
 truncate -s 0 $logname
 
+which=`ls $matrices_dir/*.csr`
+filenames=`for i in $which;do basename $i;done`
 # Run ellmv for all matrices available
-for filename in ./matrices/*.csr; do
-    $bench -f ellmv --precision s --device $dev --alpha 1 --beta 0 --iters 1000 --rocalution $filename 2>&1 | tee -a $logname
+for filename in $filenames; do
+    $bench --matrices-dir $matrices_dir -f ellmv --precision s --device $dev --alpha 1 --beta 0 --iters 1000 --rocalution $filename 2>&1 | tee -a $logname
 done


### PR DESCRIPTION
command line options for the source directory of matrices
In:
- rocsparse-test       [--matrices-dir <path>] or export ROCSPARSE_CLIENTS_MATRICES_DIR=<path>
- rocsparse-bench   [--matrices-dir <path>] or export ROCSPARSE_CLIENTS_MATRICES_DIR=<path>
- and all the shell scripts in scripts/performance, [ {-d  | --matrice-dir} <path>] or export MATRICES_DIR=<path>

