### PR TITLE
Fix failing bsrmv stress test

### DIFF
--- a/clients/testings/testing_bsrmv.cpp
+++ b/clients/testings/testing_bsrmv.cpp
@@ -212,7 +212,7 @@ void testing_bsrmv(const Arguments& arg)
     //
     // Declare and initialize matrices.
     //
-    host_gebsr_matrix<T>   hA;
+    host_gebsr_matrix<T>   hA(dir, mb, nb, 0, block_dim, block_dim, base);
     device_gebsr_matrix<T> dA;
     if(strcmp(arg.category, "stress"))
     {


### PR DESCRIPTION
Summary of proposed changes:
- This was fixed in https://github.com/ROCmSoftwarePlatform/rocSPARSE/commit/db2c9219874be7c04b1a7023d5153d733bd001ca but I don't want to cherry pick this entire PR into 5.7
