### PR TITLE
Fix gpsv minimum m size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Full documentation for rocSPARSE is available at [rocm.docs.amd.com](https://roc
 - Fixed a bug in rocsparse-bench, where SpMV algorithm was not taken into account in CSR format
 - Fixed the BSR/GEBSR routines bsrmv, bsrsv, bsrmm, bsrgeam, gebsrmv, gebsrmm so that block_dim==0 is considered an invalid size
 - Fixed bug where passing nnz = 0 to doti or dotci did not always return a dot product of 0
+- Fixed gpsv minimum size to m >= 3
 - Improved spin-looping algorithms
 - Improved documentation
 - Improved verbose output during argument checking on API function calls

--- a/clients/testings/testing_gpsv_interleaved_batch.cpp
+++ b/clients/testings/testing_gpsv_interleaved_batch.cpp
@@ -54,7 +54,7 @@ void testing_gpsv_interleaved_batch_bad_arg(const Arguments& arg)
     bad_arg_analysis(rocsparse_gpsv_interleaved_batch_buffer_size<T>, PARAMS_BUFFER_SIZE);
     bad_arg_analysis(rocsparse_gpsv_interleaved_batch<T>, PARAMS_SOLVE);
 
-    // m < 5
+    // m < 3
     m = 2;
     EXPECT_ROCSPARSE_STATUS(rocsparse_gpsv_interleaved_batch_buffer_size<T>(PARAMS_BUFFER_SIZE),
                             rocsparse_status_invalid_size);

--- a/library/src/precond/rocsparse_gpsv_interleaved_batch.cpp
+++ b/library/src/precond/rocsparse_gpsv_interleaved_batch.cpp
@@ -75,7 +75,7 @@ rocsparse_status
 
     ROCSPARSE_CHECKARG_ENUM(1, alg);
     ROCSPARSE_CHECKARG_SIZE(2, m);
-    ROCSPARSE_CHECKARG(2, m, (m < 5), rocsparse_status_invalid_size);
+    ROCSPARSE_CHECKARG(2, m, (m < 3), rocsparse_status_invalid_size);
     ROCSPARSE_CHECKARG_ARRAY(3, batch_count, ds);
     ROCSPARSE_CHECKARG_ARRAY(4, batch_count, dl);
     ROCSPARSE_CHECKARG_ARRAY(5, batch_count, d);
@@ -145,7 +145,7 @@ rocsparse_status rocsparse_gpsv_interleaved_batch_template(rocsparse_handle     
 
     ROCSPARSE_CHECKARG_ENUM(1, alg);
     ROCSPARSE_CHECKARG_SIZE(2, m);
-    ROCSPARSE_CHECKARG(2, m, (m < 5), rocsparse_status_invalid_size);
+    ROCSPARSE_CHECKARG(2, m, (m < 3), rocsparse_status_invalid_size);
     ROCSPARSE_CHECKARG_ARRAY(3, batch_count, ds);
     ROCSPARSE_CHECKARG_ARRAY(4, batch_count, dl);
     ROCSPARSE_CHECKARG_ARRAY(5, batch_count, d);


### PR DESCRIPTION
The minimum size $m$ is not valid in the code according to the documentation.

Therefore the [GPSV example](https://github.com/ROCmSoftwarePlatform/rocSPARSE/blob/develop/clients/samples/example_gpsv.cpp) in this repo does not work.

Summary of proposed changes:
- fix to $m\ge3$ in the code
- fix to $m\ge3$ in the test description
- update CHANGELOG
