### PR TITLE
SWDEV-415164 (#656)

### DIFF
--- a/library/src/level3/rocsparse_csrsm_solve.cpp
+++ b/library/src/level3/rocsparse_csrsm_solve.cpp
@@ -235,14 +235,16 @@ rocsparse_status rocsparse_csrsm_solve_dispatch(rocsparse_handle          handle
         dim3 csrsm_threads(blockdim);
 
         // Determine gcnArch and ASIC revision
-        int gcnArch = handle->properties.gcnArch;
-        int asicRev = handle->asic_rev;
+
+        const std::string gcn_arch_name = rocsparse_handle_get_arch_name(handle);
+        int               asicRev       = handle->asic_rev;
 
         // rocsparse_pointer_mode_device
 
         if(blockdim == 64)
         {
-            if(gcnArch == 908 && asicRev < 2)
+
+            if(gcn_arch_name == rocpsarse_arch_names::gfx908 && asicRev < 2)
             {
                 hipLaunchKernelGGL((csrsm<64, 64, true>),
                                    csrsm_blocks,
@@ -291,7 +293,7 @@ rocsparse_status rocsparse_csrsm_solve_dispatch(rocsparse_handle          handle
         }
         else if(blockdim == 128)
         {
-            if(gcnArch == 908 && asicRev < 2)
+            if(gcn_arch_name == rocpsarse_arch_names::gfx908 && asicRev < 2)
             {
                 hipLaunchKernelGGL((csrsm<128, 64, true>),
                                    csrsm_blocks,
@@ -340,7 +342,7 @@ rocsparse_status rocsparse_csrsm_solve_dispatch(rocsparse_handle          handle
         }
         else if(blockdim == 256)
         {
-            if(gcnArch == 908 && asicRev < 2)
+            if(gcn_arch_name == rocpsarse_arch_names::gfx908 && asicRev < 2)
             {
                 hipLaunchKernelGGL((csrsm<256, 64, true>),
                                    csrsm_blocks,
@@ -389,7 +391,7 @@ rocsparse_status rocsparse_csrsm_solve_dispatch(rocsparse_handle          handle
         }
         else if(blockdim == 512)
         {
-            if(gcnArch == 908 && asicRev < 2)
+            if(gcn_arch_name == rocpsarse_arch_names::gfx908 && asicRev < 2)
             {
                 hipLaunchKernelGGL((csrsm<512, 64, true>),
                                    csrsm_blocks,
@@ -438,7 +440,7 @@ rocsparse_status rocsparse_csrsm_solve_dispatch(rocsparse_handle          handle
         }
         else if(blockdim == 1024)
         {
-            if(gcnArch == 908 && asicRev < 2)
+            if(gcn_arch_name == rocpsarse_arch_names::gfx908 && asicRev < 2)
             {
                 hipLaunchKernelGGL((csrsm<1024, 64, true>),
                                    csrsm_blocks,

--- a/library/src/precond/rocsparse_bsric0.cpp
+++ b/library/src/precond/rocsparse_bsric0.cpp
@@ -257,7 +257,9 @@ inline void bsric0_launcher(rocsparse_handle     handle,
     }
     else
     {
-        if(handle->properties.gcnArch == 908 && handle->asic_rev < 2)
+
+        const std::string gcn_arch_name = rocsparse_handle_get_arch_name(handle);
+        if(gcn_arch_name == rocpsarse_arch_names::gfx908 && handle->asic_rev < 2)
         {
             LAUNCH_BSRIC_33_inf(T, 64, 64, true);
         }

--- a/library/src/precond/rocsparse_bsrilu0.cpp
+++ b/library/src/precond/rocsparse_bsrilu0.cpp
@@ -460,7 +460,8 @@ inline void bsrilu0_launcher(rocsparse_handle     handle,
                              U                    boost_tol_device_host,
                              V                    boost_val_device_host)
 {
-    if(handle->properties.gcnArch == 908 && handle->asic_rev < 2)
+    const std::string gcn_arch_name = rocsparse_handle_get_arch_name(handle);
+    if(gcn_arch_name == rocpsarse_arch_names::gfx908 && handle->asic_rev < 2)
     {
         LAUNCH_BSRILU65inf(true, 64);
     }
@@ -510,7 +511,9 @@ inline void bsrilu0_launcher(rocsparse_handle     handle,
                              U                    boost_tol_device_host,
                              V                    boost_val_device_host)
 {
-    if(handle->properties.gcnArch == 908 && handle->asic_rev < 2)
+
+    const std::string gcn_arch_name = rocsparse_handle_get_arch_name(handle);
+    if(gcn_arch_name == rocpsarse_arch_names::gfx908 && handle->asic_rev < 2)
     {
         LAUNCH_BSRILU65inf(true, 64);
     }

--- a/library/src/precond/rocsparse_csric0.cpp
+++ b/library/src/precond/rocsparse_csric0.cpp
@@ -229,14 +229,13 @@ rocsparse_status rocsparse_csric0_template(rocsparse_handle          handle, //0
     rocsparse_int max_nnz = info->csric0_info->max_nnz;
 
     // Determine gcnArch and ASIC revision
-    int gcnArch = handle->properties.gcnArch;
-    int asicRev = handle->asic_rev;
+    const std::string gcn_arch_name = rocsparse_handle_get_arch_name(handle);
 
 #define CSRIC0_DIM 256
     dim3 csric0_blocks((m * handle->wavefront_size - 1) / CSRIC0_DIM + 1);
     dim3 csric0_threads(CSRIC0_DIM);
 
-    if(gcnArch == 908 && asicRev < 2)
+    if(gcn_arch_name == rocpsarse_arch_names::gfx908 && handle->asic_rev < 2)
     {
         hipLaunchKernelGGL((csric0_binsearch_kernel<CSRIC0_DIM, 64, true>),
                            csric0_blocks,

--- a/library/src/precond/rocsparse_csrilu0.cpp
+++ b/library/src/precond/rocsparse_csrilu0.cpp
@@ -181,14 +181,13 @@ rocsparse_status rocsparse_csrilu0_dispatch(rocsparse_handle          handle,
     rocsparse_int max_nnz = info->csrilu0_info->max_nnz;
 
     // Determine gcnArch and ASIC revision
-    int gcnArch = handle->properties.gcnArch;
-    int asicRev = handle->asic_rev;
+    const std::string gcn_arch_name = rocsparse_handle_get_arch_name(handle);
 
 #define CSRILU0_DIM 256
     dim3 csrilu0_blocks((m * handle->wavefront_size - 1) / CSRILU0_DIM + 1);
     dim3 csrilu0_threads(CSRILU0_DIM);
 
-    if(gcnArch == 908 && asicRev < 2)
+    if(gcn_arch_name == rocpsarse_arch_names::gfx908 && handle->asic_rev < 2)
     {
         hipLaunchKernelGGL((csrilu0_binsearch<CSRILU0_DIM, 64, true>),
                            csrilu0_blocks,


### PR DESCRIPTION
* the use of gcnarch has been somehow reverted from the many commits related to argument checkings

resolves #SWDEV-415164

