### PR TITLE
removes unnecessary inclusions of unistd.h and sys/types.h

### DIFF
--- a/library/src/rocsparse_argdescr.cpp
+++ b/library/src/rocsparse_argdescr.cpp
@@ -30,8 +30,6 @@
 #include <map>
 
 #include "debug.h"
-#include <sys/types.h>
-#include <unistd.h>
 
 int64_t rocsparse_get_pid()
 {

--- a/library/src/rocsparse_message.cpp
+++ b/library/src/rocsparse_message.cpp
@@ -28,9 +28,6 @@
 #include "envariables.h"
 #include <map>
 
-#include <sys/types.h>
-#include <unistd.h>
-
 void rocsparse_message(const char* msg_, const char* function_, const char* file_, int line_)
 {
     if(rocsparse_debug_variables.get_debug_verbose())


### PR DESCRIPTION
resolves #SWDEV-429034

Summary of proposed changes:

removes unnecessary inclusions of unistd.h and sys/types.h
Fixes by @YvanMokwinski
Merging fix from release-staging after tests passed