### PR TITLE
Skip tests that take too long on gfx940 and gfx941 hardware (#669)

### DIFF
--- a/clients/tests/test_bsric0.yaml
+++ b/clients/tests/test_bsric0.yaml
@@ -147,10 +147,25 @@ Tests:
   baseA: [rocsparse_index_base_zero]
   direction: [rocsparse_direction_column]
   matrix: [rocsparse_matrix_file_rocalution]
-  filename: [ASIC_320k,
-             amazon0312,
-             Chebyshev4,
+  filename: [amazon0312,
              mac_econ_fwd500]
+
+- name: bsric0_file
+  category: nightly
+  function: bsric0
+  precision: *single_double_precisions
+  M: 1
+  N: 1
+  block_dim: [3]
+  transA: [rocsparse_operation_none]
+  apol: [rocsparse_analysis_policy_reuse]
+  spol: [rocsparse_solve_policy_auto]
+  baseA: [rocsparse_index_base_zero]
+  direction: [rocsparse_direction_column]
+  matrix: [rocsparse_matrix_file_rocalution]
+  filename: [ASIC_320k,
+             Chebyshev4]
+  skip_hardware: gfx940, gfx941
 
 - name: bsric0_file
   category: quick

--- a/clients/tests/test_csric0.yaml
+++ b/clients/tests/test_csric0.yaml
@@ -1,5 +1,5 @@
 # ########################################################################
-# Copyright (C) 2019-2022 Advanced Micro Devices, Inc. All rights Reserved.
+# Copyright (C) 2019-2023 Advanced Micro Devices, Inc. All rights Reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -147,12 +147,25 @@ Tests:
   spol: [rocsparse_solve_policy_auto]
   baseA: [rocsparse_index_base_zero, rocsparse_index_base_one]
   matrix: [rocsparse_matrix_file_rocalution]
-  filename: [ASIC_320k,
-             amazon0312,
-             Chebyshev4,
+  filename: [amazon0312,
              nos3,
              nos5,
              nos7]
+
+- name: csric0_file
+  category: nightly
+  function: csric0
+  precision: *single_double_precisions
+  M: 1
+  N: 1
+  transA: [rocsparse_operation_none]
+  apol: [rocsparse_analysis_policy_reuse, rocsparse_analysis_policy_force]
+  spol: [rocsparse_solve_policy_auto]
+  baseA: [rocsparse_index_base_zero, rocsparse_index_base_one]
+  matrix: [rocsparse_matrix_file_rocalution]
+  filename: [ASIC_320k,
+             Chebyshev4]
+  skip_hardware: gfx940, gfx941
 
 - name: csric0_file
   category: quick

--- a/clients/tests/test_csrilu0.yaml
+++ b/clients/tests/test_csrilu0.yaml
@@ -1,5 +1,5 @@
 # ########################################################################
-# Copyright (C) 2019-2022 Advanced Micro Devices, Inc. All rights Reserved.
+# Copyright (C) 2019-2023 Advanced Micro Devices, Inc. All rights Reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -137,11 +137,24 @@ Tests:
   baseA: [rocsparse_index_base_zero, rocsparse_index_base_one]
   matrix: [rocsparse_matrix_file_rocalution]
   filename: [mc2depi,
-             ASIC_320k,
              nos1,
              nos3,
              nos5,
              nos7]
+
+- name: csrilu0_file
+  category: pre_checkin
+  function: csrilu0
+  precision: *single_double_precisions
+  M: 1
+  N: 1
+  transA: [rocsparse_operation_none]
+  apol: [rocsparse_analysis_policy_reuse, rocsparse_analysis_policy_force]
+  spol: [rocsparse_solve_policy_auto]
+  baseA: [rocsparse_index_base_zero, rocsparse_index_base_one]
+  matrix: [rocsparse_matrix_file_rocalution]
+  filename: [ASIC_320k]
+  skip_hardware: gfx940, gfx941
 
 - name: csrilu0_file
   category: nightly
@@ -156,9 +169,22 @@ Tests:
   matrix: [rocsparse_matrix_file_rocalution]
   filename: [bmwcra_1,
              amazon0312,
-             Chebyshev4,
              sme3Dc,
              webbase-1M]
+
+- name: csrilu0_file
+  category: nightly
+  function: csrilu0
+  precision: *single_double_precisions
+  M: 1
+  N: 1
+  transA: [rocsparse_operation_none]
+  apol: [rocsparse_analysis_policy_reuse, rocsparse_analysis_policy_force]
+  spol: [rocsparse_solve_policy_auto]
+  baseA: [rocsparse_index_base_zero, rocsparse_index_base_one]
+  matrix: [rocsparse_matrix_file_rocalution]
+  filename: [Chebyshev4]
+  skip_hardware: gfx940, gfx941
 
 - name: csrilu0_file
   category: quick


### PR DESCRIPTION
Summary of proposed changes:
- Cherrypicks in https://github.com/ROCmSoftwarePlatform/rocSPARSE-internal/pull/669 to 6.0 branch
