### PR TITLE
Fix asan failures seen on CI when building rocsparse with fortran (#698)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ########################################################################
-# Copyright (C) 2018-2023 Advanced Micro Devices, Inc. All rights Reserved.
+# Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights Reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -51,7 +51,7 @@ if(POLICY CMP0066)
 endif()
 
 # rocSPARSE project
-project(rocsparse LANGUAGES CXX Fortran C)
+project(rocsparse LANGUAGES CXX C)
 
 # Determine if CXX Compiler is hip-clang
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
@@ -77,6 +77,11 @@ option(BUILD_MEMSTAT "Build rocSPARSE with memory statistics enabled" OFF)
 option(BUILD_COMPRESSED_DBG "Enable compressed debug symbols" ON)
 option(BUILD_WITH_ROCBLAS "Enable building rocSPARSE with rocBLAS" ON)
 
+# Clients utilize rocsparse fortran API and a fortran compiler
+if( NOT BUILD_FORTRAN_CLIENTS )
+  option( BUILD_FORTRAN_CLIENTS "Build rocSPARSE clients requiring Fortran capabilities" ON )
+endif( )
+
 #
 if(BUILD_CODE_COVERAGE)
   add_compile_options(-fprofile-arcs -ftest-coverage)
@@ -97,22 +102,8 @@ if(BUILD_ADDRESS_SANITIZER)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=address -shared-libasan")
   set(CMAKE_C_LINK_EXECUTABLE "${CMAKE_C_LINK_EXECUTABLE} -fuse-ld=lld")
 
-  # Fortran excluded (see NOTES below)
-  # set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fsanitize=address")
-  # set(CMAKE_Fortran_LINK_EXECUTABLE "${CMAKE_Fortran_LINK_EXECUTABLE} -fuse-ld=bfd")
-
-  #
-  # NOTES ON FORTRAN:
-  # Fortran samples can compile with the options above:
-  # > -shared-libasan and -fuse-ld=lld is not always recognized from gfortran
-  # > -fuse-ld=bfd is here to mimic the required -fuse-ld=lld, but it compiles without too.
-  # However, error from asan is popping up from running a Fortran sample:
-  # ==14708==AddressSanitizer CHECK failed: /src/external/llvm-project/compiler-rt/lib/asan/../sanitizer_common/sanitizer_common_interceptors.inc:10057 "((__interception::real_memcpy)) != (0)" (0x0, 0x0)
-  #
-  # !!!!
-  # For this reason, and to be consistent with other libraries, Fortran is excluded from the address sanitizer build.
-  # !!!!
-  #
+  # Fortran not supported, add_link_options below invalid for fortran linking
+  set(BUILD_FORTRAN_CLIENTS OFF)
 endif()
 
 # Dependencies
@@ -128,8 +119,6 @@ if(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY AND NOT WIN32)
     WRAPPER_LOCATIONS ${CMAKE_INSTALL_INCLUDEDIR}
   )
 endif()
-
-
 
 # Detect compiler support for target ID
 if(CMAKE_CXX_COMPILER MATCHES ".*/hipcc$")

--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ########################################################################
-# Copyright (C) 2018-2023 Advanced Micro Devices, Inc. All rights Reserved.
+# Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights Reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -43,8 +43,31 @@ if(NOT DEFINED CMAKE_CONFIGURATION_TYPES AND NOT DEFINED CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel.")
 endif()
 
+if ( NOT DEFINED CMAKE_Fortran_COMPILER AND NOT DEFINED ENV{FC} )
+  set( CMAKE_Fortran_COMPILER "gfortran" )
+endif()
+
 # This project may compile dependencies for clients
-project(rocsparse-clients LANGUAGES CXX)
+if ( BUILD_FORTRAN_CLIENTS )
+  set( fortran_language "Fortran" )
+endif()
+
+# This project may compile dependencies for clients
+project(rocsparse-clients LANGUAGES CXX ${fortran_language})
+
+if ( BUILD_FORTRAN_CLIENTS )
+  set(rocsparse_fortran_source
+      ../library/src/rocsparse_enums.f90
+      ../library/src/rocsparse.f90
+  )
+
+  # Set Fortran module output directory
+  set(CMAKE_Fortran_MODULE_DIRECTORY ${PROJECT_BINARY_DIR}/include/rocsparse)
+
+  # Create rocBLAS Fortran module
+  add_library(rocsparse_fortran OBJECT ${rocsparse_fortran_source})
+
+endif()
 
 # Determine if CXX Compiler is hip-clang
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")

--- a/clients/samples/CMakeLists.txt
+++ b/clients/samples/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ########################################################################
-# Copyright (C) 2018-2022 Advanced Micro Devices, Inc. All rights Reserved.
+# Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights Reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -100,10 +100,10 @@ if(TARGET rocsparse)
   # Compile Fortran examples only if built directly with package
   # else the Fortran module file is not generated
 
-  # BUILD_ADDRESS_SANITIZER EXCLUDED, SEE NOTES IN THE ROOT CMakeLists.txt.
-  if (NOT WIN32 AND NOT BUILD_ADDRESS_SANITIZER)
+  if (NOT WIN32 AND BUILD_FORTRAN_CLIENTS)
 
     function(add_rocsparse_fortran_example EXAMPLE_SOURCE)
+      set( fortran_language "Fortran" )
       get_filename_component(EXAMPLE_TARGET ${EXAMPLE_SOURCE} NAME_WE)
       add_executable(${EXAMPLE_TARGET} ${EXAMPLE_SOURCE})
 
@@ -116,8 +116,10 @@ if(TARGET rocsparse)
       # Linker dependencies
       target_link_libraries(${EXAMPLE_TARGET} PRIVATE roc::rocsparse hip::host)
       if (BUILD_CODE_COVERAGE)
-	target_link_libraries(${EXAMPLE_TARGET} PRIVATE -lgcov)
+	      target_link_libraries(${EXAMPLE_TARGET} PRIVATE -lgcov)
       endif()
+
+      target_link_libraries( ${EXAMPLE_TARGET} PRIVATE rocsparse_fortran )
 
       # Target properties
       set_target_properties(${EXAMPLE_TARGET} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/staging")

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ########################################################################
-# Copyright (C) 2018-2023 Advanced Micro Devices, Inc. All rights Reserved.
+# Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights Reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -62,17 +62,6 @@ source_group("Header Files\\Public" FILES ${rocsparse_headers_public})
 # Include sources
 include(src/CMakeLists.txt)
 
-if (NOT WIN32)
-# Set Fortran module output directory
-set(CMAKE_Fortran_MODULE_DIRECTORY ${PROJECT_BINARY_DIR}/include/rocsparse)
-
-# Create rocSPARSE Fortran module
-add_library(rocsparse_fortran OBJECT ${rocsparse_fortran_source})
-
-# Target compile options
-target_compile_options(rocsparse_fortran PRIVATE -std=f2003 -ffree-form -cpp)
-endif()
-
 # Create rocSPARSE library
 add_library(rocsparse ${rocsparse_source} ${rocsparse_headers_public})
 add_library(roc::rocsparse ALIAS rocsparse)
@@ -120,8 +109,6 @@ if (BUILD_FILE_REORG_BACKWARD_COMPATIBILITY AND NOT WIN32)
     WRAPPER_LOCATIONS ${CMAKE_INSTALL_INCLUDEDIR} rocsparse/${CMAKE_INSTALL_INCLUDEDIR}
   )
 endif( )
-
-
 
 # Force installation of .f module file
 rocm_install(FILES "${CMAKE_SOURCE_DIR}/library/src/rocsparse.f90"

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ########################################################################
-# Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights Reserved.
+# Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights Reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -20,14 +20,6 @@
 # THE SOFTWARE.
 #
 # ########################################################################
-
-# rocSPARSE Fortran source
-if (NOT WIN32)
-set(rocsparse_fortran_source
-  src/rocsparse_enums.f90
-  src/rocsparse.f90
-)
-endif()
 
 # rocSPARSE source
 set(rocsparse_source
@@ -298,8 +290,6 @@ set(rocsparse_source
   src/conversion/rocsparse_sparse_to_csr_to_sparse.cpp
   src/conversion/rocsparse_spmat_transfer_from.cpp
   src/conversion/rocsparse_internal_spmat_print.cpp
-
-
 
 # Reordering
   src/reordering/rocsparse_csrcolor.cpp


### PR DESCRIPTION
* Fixing fortran asan build issues occuring on CI

* Fix fortran asan builds

* Remove testing comments

* Remove comments

* Remove statement
