### PR TITLE
Add req_memory option to yaml test files (#699)

### DIFF
--- a/clients/include/rocsparse_arguments.hpp
+++ b/clients/include/rocsparse_arguments.hpp
@@ -1,6 +1,6 @@
 /*! \file */
 /* ************************************************************************
- * Copyright (C) 2019-2023 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -153,6 +153,8 @@ struct Arguments
     char hardware[32];
     char skip_hardware[32];
 
+    uint32_t req_memory;
+
     // Validate input format.
     // rocsparse_gentest.py is expected to conform to this format.
     // rocsparse_gentest.py uses rocsparse_common.yaml to generate this format.
@@ -284,6 +286,7 @@ struct Arguments
         ROCSPARSE_FORMAT_CHECK(category);
         ROCSPARSE_FORMAT_CHECK(hardware);
         ROCSPARSE_FORMAT_CHECK(skip_hardware);
+        ROCSPARSE_FORMAT_CHECK(req_memory);
     }
 
     template <typename T>
@@ -491,6 +494,7 @@ private:
         print("category", arg.category);
         print("hardware", arg.hardware);
         print("skip_hardware", arg.skip_hardware);
+        print("req_memory", arg.req_memory);
         print("unit_check", arg.unit_check);
         print("timing", arg.timing);
         print("iters", arg.iters);

--- a/clients/include/rocsparse_common.yaml
+++ b/clients/include/rocsparse_common.yaml
@@ -1,5 +1,5 @@
 # ########################################################################
-# Copyright (C) 2019-2023 Advanced Micro Devices, Inc. All rights Reserved.
+# Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights Reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -398,6 +398,7 @@ Arguments:
   - category: c_char*32
   - hardware: c_char*32
   - skip_hardware: c_char*32
+  - req_memory: c_uint
 
 # These named dictionary lists [ {dict1}, {dict2}, etc. ] supply subsets of
 # test arguments in a structured way. The dictionaries are applied to the test
@@ -521,6 +522,7 @@ Defaults:
   category: nightly
   hardware: all
   skip_hardware: none
+  req_memory: 4
   filename: '*'
   name: '*'
   index_type_I: i32

--- a/clients/include/rocsparse_test.hpp
+++ b/clients/include/rocsparse_test.hpp
@@ -1,6 +1,6 @@
 /*! \file */
 /* ************************************************************************
- * Copyright (C) 2019-2023 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -215,7 +215,8 @@ inline void rocsparse_expect_data_status(rocsparse_data_status status, rocsparse
                               return !strcmp(arg.category, #categ0ry)          \
                                      && testclass::type_filter(arg)            \
                                      && testclass::function_filter(arg)        \
-                                     && testclass::arch_filter(arg);           \
+                                     && testclass::arch_filter(arg)            \
+                                     && testclass::memory_filter(arg);         \
                           }),                                                  \
                           RocSPARSE_TestData::end()),                          \
         testclass::PrintToStringParamName());

--- a/clients/testings/testing_spsm_csr.cpp
+++ b/clients/testings/testing_spsm_csr.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
-* Copyright (C) 2021-2023 Advanced Micro Devices, Inc. All rights Reserved.
+* Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights Reserved.
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal

--- a/clients/tests/rocsparse_test_template.hpp
+++ b/clients/tests/rocsparse_test_template.hpp
@@ -1,6 +1,6 @@
 /*! \file */
 /* ************************************************************************
-* Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights Reserved.
+* Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights Reserved.
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
@@ -157,6 +157,38 @@ namespace
                                 ;
                         }
                     }
+                }
+
+                return true;
+            }
+
+            static bool memory_filter(const Arguments& arg)
+            {
+                static double available_memory_in_GB = 0.0;
+                static bool   query_device_memory    = true;
+                if(query_device_memory)
+                {
+                    size_t available_memory;
+                    size_t total_memory;
+                    if(hipMemGetInfo(&available_memory, &total_memory) != hipSuccess)
+                    {
+                        return false;
+                    }
+
+                    available_memory_in_GB = (double)available_memory / (1024 * 1024 * 1024);
+
+                    query_device_memory = false;
+                }
+
+                if(available_memory_in_GB < arg.req_memory)
+                {
+                    std::cout << "Skipping test "
+                              << (std::string(arg.category) + "/" + std::string(arg.function) + "/"
+                                  + name_suffix(arg))
+                              << " because insufficient memory avaiable. Required: "
+                              << arg.req_memory << "GB. Available: " << available_memory_in_GB
+                              << "GB." << std::endl;
+                    return false;
                 }
 
                 return true;

--- a/clients/tests/test_bsrsm.yaml
+++ b/clients/tests/test_bsrsm.yaml
@@ -231,7 +231,25 @@ Tests:
   precision: *single_double_precisions_complex_real
   M_N: *M_N_range_nightly
   K: [32, 135]
-  block_dim: [5, 11, 33]
+  block_dim: [5, 11]
+  alpha_alphai: *alpha_range_nightly
+  direction: [rocsparse_direction_row]
+  transA: [rocsparse_operation_none, rocsparse_operation_transpose]
+  transB: [rocsparse_operation_transpose]
+  diag: [rocsparse_diag_type_unit]
+  uplo: [rocsparse_fill_mode_lower]
+  apol: [rocsparse_analysis_policy_force]
+  spol: [rocsparse_solve_policy_auto]
+  baseA: [rocsparse_index_base_zero]
+  matrix: [rocsparse_matrix_random]
+
+- name: bsrsm
+  category: nightly
+  function: bsrsm
+  precision: *double_only_precisions_complex_real
+  M_N: *M_N_range_nightly
+  K: [32, 135]
+  block_dim: [33]
   alpha_alphai: *alpha_range_nightly
   direction: [rocsparse_direction_row]
   transA: [rocsparse_operation_none, rocsparse_operation_transpose]

--- a/clients/tests/test_spsm_coo.yaml
+++ b/clients/tests/test_spsm_coo.yaml
@@ -146,8 +146,39 @@ Tests:
   filename: [nos1,
              nos5,
              nos7,
-                   mplate,
-                   Chevron3]
+             mplate]
+- name: spsm_coo_file
+  category: pre_checkin
+  function: spsm_coo
+  indextype: *i32_i64
+  precision: *single_double_precisions
+  K: [141]
+  alpha_alphai: *alpha_range_checkin
+  transA: [rocsparse_operation_transpose]
+  transB: [rocsparse_operation_none]
+  diag: [rocsparse_diag_type_non_unit]
+  uplo: [rocsparse_fill_mode_upper]
+  baseA: [rocsparse_index_base_one]
+  spsm_alg: [rocsparse_spsm_alg_default]
+  matrix: [rocsparse_matrix_file_rocalution]
+  filename: [Chevron3]
+
+- name: spsm_coo_file
+  category: pre_checkin
+  function: spsm_coo
+  indextype: *i32_i64
+  precision: *single_double_precisions
+  K: [875]
+  alpha_alphai: *alpha_range_checkin
+  transA: [rocsparse_operation_transpose]
+  transB: [rocsparse_operation_none]
+  diag: [rocsparse_diag_type_non_unit]
+  uplo: [rocsparse_fill_mode_upper]
+  baseA: [rocsparse_index_base_one]
+  spsm_alg: [rocsparse_spsm_alg_default]
+  matrix: [rocsparse_matrix_file_rocalution]
+  filename: [Chevron3]
+  req_memory: 12
 
 - name: spsm_coo_file
   category: pre_checkin
@@ -256,8 +287,25 @@ Tests:
   spsm_alg: [rocsparse_spsm_alg_default]
   matrix: [rocsparse_matrix_file_rocalution]
   filename: [bmwcra_1,
-             amazon0312,
-             sme3Dc]
+             amazon0312]
+
+- name: spsm_coo_file
+  category: nightly
+  function: spsm_coo
+  indextype: *i32_i64
+  precision: *double_only_precisions_complex_real
+  M: 1
+  N: 1
+  K: [16, 57]
+  alpha_alphai: *alpha_range_nightly_one
+  transA: [rocsparse_operation_transpose]
+  transB: [rocsparse_operation_transpose]
+  diag: [rocsparse_diag_type_non_unit]
+  uplo: [rocsparse_fill_mode_lower]
+  baseA: [rocsparse_index_base_zero]
+  spsm_alg: [rocsparse_spsm_alg_default]
+  matrix: [rocsparse_matrix_file_rocalution]
+  filename: [sme3Dc]
 
 #
 # in test definition above

--- a/clients/tests/test_spsm_csr.yaml
+++ b/clients/tests/test_spsm_csr.yaml
@@ -159,8 +159,44 @@ Tests:
   filename: [nos1,
              nos5,
              nos7,
-                   mplate,
-                   Chevron3]
+             mplate]
+
+- name: spsm_csr_file
+  category: pre_checkin
+  function: spsm_csr
+  indextype: *i32i32_i64i32_i64i64
+  precision: *single_double_precisions
+  K: [141]
+  ld_multiplier_B: [1]
+  ld_multiplier_C: [1]
+  alpha_alphai: *alpha_range_checkin
+  transA: [rocsparse_operation_transpose]
+  transB: [rocsparse_operation_none]
+  diag: [rocsparse_diag_type_non_unit]
+  uplo: [rocsparse_fill_mode_upper]
+  baseA: [rocsparse_index_base_one]
+  spsm_alg: [rocsparse_spsm_alg_default]
+  matrix: [rocsparse_matrix_file_rocalution]
+  filename: [Chevron3]
+  
+- name: spsm_csr_file
+  category: pre_checkin
+  function: spsm_csr
+  indextype: *i32i32_i64i32_i64i64
+  precision: *single_double_precisions
+  K: [875]
+  ld_multiplier_B: [1]
+  ld_multiplier_C: [1]
+  alpha_alphai: *alpha_range_checkin
+  transA: [rocsparse_operation_transpose]
+  transB: [rocsparse_operation_none]
+  diag: [rocsparse_diag_type_non_unit]
+  uplo: [rocsparse_fill_mode_upper]
+  baseA: [rocsparse_index_base_one]
+  spsm_alg: [rocsparse_spsm_alg_default]
+  matrix: [rocsparse_matrix_file_rocalution]
+  filename: [Chevron3]
+  req_memory: 12
 
 - name: spsm_csr_file
   category: pre_checkin
@@ -281,8 +317,27 @@ Tests:
   spsm_alg: [rocsparse_spsm_alg_default]
   matrix: [rocsparse_matrix_file_rocalution]
   filename: [bmwcra_1,
-             amazon0312,
-             sme3Dc]
+             amazon0312]
+
+- name: spsm_csr_file
+  category: nightly
+  function: spsm_csr
+  indextype: *i32i32_i64i32_i64i64
+  precision: *double_only_precisions_complex_real
+  M: 1
+  N: 1
+  K: [16, 57]
+  ld_multiplier_B: [1]
+  ld_multiplier_C: [1]
+  alpha_alphai: *alpha_range_nightly_one
+  transA: [rocsparse_operation_transpose]
+  transB: [rocsparse_operation_transpose]
+  diag: [rocsparse_diag_type_non_unit]
+  uplo: [rocsparse_fill_mode_lower]
+  baseA: [rocsparse_index_base_zero]
+  spsm_alg: [rocsparse_spsm_alg_default]
+  matrix: [rocsparse_matrix_file_rocalution]
+  filename: [sme3Dc]
 
 #
 # in test definition above


### PR DESCRIPTION
* Adding req_memory option to test yaml files

* clang formatting

* clang formatting

* Sanitizer failures

* clang formatting

* Use hipMemGetInfo

* Change minimum required gpu memory to 4gb for tests

* Clang formatting

