### PR TITLE
Update index.rst to fix broken references

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,15 +25,15 @@ The rocSPARSE documentation is structured as follows:
 
   .. grid-item-card:: How to
 
-    * :ref:`rocsparse-docs`
-    * :ref:`rocsparse-logging`
+    * :ref:`rocsparse_docs`
+    * :ref:`rocsparse_logging`
     * :ref:`design`
     * :ref:`contributing-to`
 
   .. grid-item-card:: API reference
 
     * :ref:`api`
-    * :ref:`rocsparse-types`
+    * :ref:`rocsparse_types`
     * :ref:`rocsparse_auxiliary_functions_`
     * :ref:`rocsparse_level1_functions_` 
     * :ref:`rocsparse_level2_functions_` 


### PR DESCRIPTION
Corrected broken links:
rocsparse-docs > rocsparse_docs
rocsparse-logging > rocsparse_logging
...

resolves #___

Summary of proposed changes:
-
-
-
