### PR TITLE
Use correct fortran package name for mariner OS (#813)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,6 +213,8 @@ if( BUILD_CLIENTS_SAMPLES OR BUILD_CLIENTS_TESTS OR BUILD_CLIENTS_BENCHMARKS )
     set(GFORTRAN_DEB "libgfortran5")
   elseif(CLIENTS_OS STREQUAL "sles" AND OPENMP_FOUND)
     set(OPENMP_RPM "libgomp1")
+  elseif(CLIENTS_OS STREQUAL "mariner")
+    set(GFORTRAN_RPM "gfortran")
   endif()
 
   rocm_package_setup_component(clients)


### PR DESCRIPTION
Summary of proposed changes:
- Cherry-pick commit 6d51a18bf8237f1f6fbef04846491cc4a9fb967d into release/rocm-rel-6.2
