### PR TITLE
Cherry-pick to docs/6.2.2: Add missing metadata (#861)

### DIFF
--- a/docs/license.rst
+++ b/docs/license.rst
@@ -1,3 +1,7 @@
+.. meta::
+  :description: rocSPARSE licensing information
+  :keywords: rocSPARSE, ROCm, API, license, documentation
+
 License
 =======
 

--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -1,3 +1,7 @@
+.. meta::
+  :description: rocSPARSE API reference library documentation
+  :keywords: rocSPARSE, ROCm, API, documentation
+
 .. _api:
 
 Exported rocSPARSE Functions

--- a/docs/reference/reproducibility.rst
+++ b/docs/reference/reproducibility.rst
@@ -1,3 +1,7 @@
+.. meta::
+  :description: rocSPARSE bitwise reproducibility API reference library documentation
+  :keywords: rocSPARSE, ROCm, API, documentation
+
 .. _reproducibility:
 
 Bitwise reproducibility


### PR DESCRIPTION
* Add missing metadata

* Correct metadata on license file

resolves #___

Summary of proposed changes:
- Port Metadata fix from develop
-
-
