### PR TITLE
Skip some tests on gfx1151 APU that consume too much memory (#874)

### DIFF
--- a/clients/tests/test_bsrgemm.yaml
+++ b/clients/tests/test_bsrgemm.yaml
@@ -124,9 +124,7 @@ Tests:
   matrix_init_kind: [rocsparse_matrix_init_kind_tunedavg]
   matrix: [rocsparse_matrix_file_rocalution]
   filename: [scircuit,
-             amazon0312,
              bmwcra_1,
-             sme3Dc,
              rma10,
              shipsec1,
              Chevron3,
@@ -134,6 +132,29 @@ Tests:
              qc2534,
              mplate,
              mac_econ_fwd500]
+
+- name: bsrgemm_mult_file
+  category: nightly
+  function: bsrgemm
+  precision: *single_double_precisions
+  M: 1
+  N: [2200]
+  K: 1
+  block_dim: [3, 24]
+  alpha_alphai: *alpha_range_nightly
+  beta_betai: *beta_range_nightly
+  transA: [rocsparse_operation_none]
+  transB: [rocsparse_operation_none]
+  baseA: [rocsparse_index_base_zero]
+  baseB: [rocsparse_index_base_one]
+  baseC: [rocsparse_index_base_zero]
+  baseD: [rocsparse_index_base_one]
+  direction: [rocsparse_direction_column]
+  matrix_init_kind: [rocsparse_matrix_init_kind_tunedavg]
+  matrix: [rocsparse_matrix_file_rocalution]
+  filename: [amazon0312,
+             sme3Dc]
+  skip_hardware: gfx1151
 
 # C = alpha * A * B
 - name: bsrgemm_mult

--- a/clients/tests/test_spgemm_bsr.yaml
+++ b/clients/tests/test_spgemm_bsr.yaml
@@ -215,8 +215,28 @@ Tests:
   direction: [rocsparse_direction_column]
   matrix: [rocsparse_matrix_file_rocalution]
   spgemm_alg: [rocsparse_spgemm_alg_default]
-  filename: [mplate,
-             Chevron3]
+  filename: [mplate]
+
+- name: spgemm_mult_bsr_file
+  category: pre_checkin
+  function: spgemm_bsr
+  indextype: *i64
+  precision: *single_double_precisions_complex
+  M: 1
+  N: [2014]
+  K: 1
+  block_dim: [9]
+  alpha_beta: *alpha_beta_range_checkin
+  transA: [rocsparse_operation_none]
+  transB: [rocsparse_operation_none]
+  baseA: [rocsparse_index_base_one]
+  baseB: [rocsparse_index_base_zero]
+  baseC: [rocsparse_index_base_one]
+  direction: [rocsparse_direction_column]
+  matrix: [rocsparse_matrix_file_rocalution]
+  spgemm_alg: [rocsparse_spgemm_alg_default]
+  filename: [Chevron3]
+  skip_hardware: gfx1151
 
 - name: spgemm_mult_bsr_file
   category: nightly

--- a/clients/tests/test_spmv_bsr.yaml
+++ b/clients/tests/test_spmv_bsr.yaml
@@ -181,6 +181,7 @@ Tests:
   baseA: [rocsparse_index_base_zero]
   matrix: [rocsparse_matrix_file_rocalution]
   filename: [Chevron4]
+  skip_hardware: gfx1151
 
 - name: spmv_bsr_graph_test
   category: pre_checkin

--- a/clients/tests/test_spsm_coo.yaml
+++ b/clients/tests/test_spsm_coo.yaml
@@ -274,6 +274,7 @@ Tests:
   spsm_alg: [rocsparse_spsm_alg_default]
   matrix: [rocsparse_matrix_file_rocalution]
   filename: [Chevron3]
+  skip_hardware: gfx1151
   req_memory: 12
 
 - name: spsm_coo_file

--- a/clients/tests/test_spsm_csr.yaml
+++ b/clients/tests/test_spsm_csr.yaml
@@ -206,6 +206,7 @@ Tests:
   spsm_alg: [rocsparse_spsm_alg_default]
   matrix: [rocsparse_matrix_file_rocalution]
   filename: [Chevron3]
+  skip_hardware: gfx1151
   req_memory: 12
 
 - name: spsm_csr_file


### PR DESCRIPTION
Summary of proposed changes:
- Cherrypick https://github.com/ROCm/rocSPARSE/commit/33af5ae77e0247ae53efdb05de422c341e0b8ba2 in 6.3
