### PR TITLE
Cherrypick relaxed spitsv_csr tolerance 

### DIFF
--- a/clients/testings/testing_spitsv_csr.cpp
+++ b/clients/testings/testing_spitsv_csr.cpp
@@ -95,7 +95,7 @@ void testing_spitsv_csr_bad_arg(const Arguments& arg)
 template <typename I, typename J, typename T>
 void testing_spitsv_csr(const Arguments& arg)
 {
-
+    auto tol = get_near_check_tol<T>(arg);
     //
     // Set nmaxiter.
     //
@@ -330,8 +330,8 @@ void testing_spitsv_csr(const Arguments& arg)
                 rocsparse_reproducibility::save(
                     "Y pointe mode host", hy_1, "Y pointe mode device", hy_2);
             }
-            hy_gold.near_check(hy_1);
-            hy_gold.near_check(hy_2);
+            hy_gold.near_check(hy_1, tol);
+            hy_gold.near_check(hy_2, tol);
         }
     }
 

--- a/clients/tests/test_spitsv_csr.yaml
+++ b/clients/tests/test_spitsv_csr.yaml
@@ -183,7 +183,24 @@ Tests:
   category: nightly
   function: spitsv_csr
   indextype: *i32i32_i64i32_i64i64
-  precision: *single_double_precisions_complex
+  precision: *single_precision_complex
+  M: 1
+  N: 1
+  tolm: 4
+  alpha_alphai: *alpha_range_nightly
+  transA: [rocsparse_operation_none, rocsparse_operation_conjugate_transpose]
+  diag: [rocsparse_diag_type_non_unit, rocsparse_diag_type_unit]
+  uplo: [rocsparse_fill_mode_lower]
+  baseA: [rocsparse_index_base_zero]
+  spitsv_alg: [rocsparse_spitsv_alg_default]
+  matrix: [rocsparse_matrix_file_rocalution]
+  filename: [Chevron4]
+
+- name: spitsv_csr_file
+  category: nightly
+  function: spitsv_csr
+  indextype: *i32i32_i64i32_i64i64
+  precision: *double_precision_complex
   M: 1
   N: 1
   alpha_alphai: *alpha_range_nightly


### PR DESCRIPTION
relax the tolerance for the nightly/spitsv_csr.level2/*_f32_c_1_1_n0p75_0p25_CT_0b_ND_L_default_csr_Chevron4 tests (#953)
