### PR TITLE
Add missing chrono header

### DIFF
--- a/clients/benchmarks/rocsparse_bench_app.cpp
+++ b/clients/benchmarks/rocsparse_bench_app.cpp
@@ -25,6 +25,7 @@
 #include "rocsparse_bench_app.hpp"
 #include "rocsparse_bench.hpp"
 #include "rocsparse_random.hpp"
+#include <chrono>
 #include <fstream>
 
 rocsparse_bench_app* rocsparse_bench_app::s_instance = nullptr;


### PR DESCRIPTION
 `rocsparse_bench_app.cpp` uses std::chrono without importing it and fails to build with Microsoft's runtime library.