### PR TITLE
Change required memory needed for SpMM BSR format test

### DIFF
--- a/clients/tests/test_spmm_bsr.yaml
+++ b/clients/tests/test_spmm_bsr.yaml
@@ -494,7 +494,7 @@ Tests:
   orderB: [rocsparse_order_column]
   orderC: [rocsparse_order_column]
   filename: [Chevron4]
-  req_memory: 14
+  req_memory: 18
 
 - name: spmm_bsr_file
   category: nightly


### PR DESCRIPTION
Summary of proposed changes:
- SpMM BSR format test was marked as requiring 14 Gb but actually requires 14.6. Marking as requiring 18 to provide safety buffer

