### PR TITLE
Add missing half precisions to axpby and sddmm documentation

### DIFF
--- a/library/include/internal/generic/rocsparse_axpby.h
+++ b/library/include/internal/generic/rocsparse_axpby.h
@@ -68,6 +68,13 @@ extern "C" {
 *  <tr><td>rocsparse_datatype_f64_c
 *  </table>
 *
+*  \par Mixed precisions:
+*  <table>
+*  <caption id="axpby_mixed">Mixed Precisions</caption>
+*  <tr><th>X / Y                   <th>compute_type
+*  <tr><td>rocsparse_datatype_f16_r <td>rocsparse_datatype_f32_r
+*  </table>
+*
 *  \note
 *  This function is non blocking and executed asynchronously with respect to the host.
 *  It may return before the actual computation has finished.

--- a/library/include/internal/generic/rocsparse_dense_to_sparse.h
+++ b/library/include/internal/generic/rocsparse_dense_to_sparse.h
@@ -79,10 +79,21 @@ extern "C" {
 *  Currently, \p rocsparse_dense_to_sparse only supports the algorithm \ref rocsparse_dense_to_sparse_alg_default. 
 *  See full example below.
 *
-*  \p rocsparse_dense_to_sparse supports \ref rocsparse_datatype_f32_r, \ref rocsparse_datatype_f64_r, 
+*  \p rocsparse_dense_to_sparse supports \ref rocsparse_datatype_f16_r, \ref rocsparse_datatype_f32_r, \ref rocsparse_datatype_f64_r, 
 *  \ref rocsparse_datatype_f32_c, and \ref rocsparse_datatype_f64_c for values arrays in the sparse matrix (stored in 
 *  CSR, CSC, or COO format) and the dense matrix. For the row/column offset and row/column index arrays of the sparse matrix, 
 *  \p rocsparse_dense_to_sparse supports the precisions \ref rocsparse_indextype_i32 and \ref rocsparse_indextype_i64.
+*
+*  \par Uniform Precisions:
+*  <table>
+*  <caption id="dense_to_sparse_uniform">Uniform Precisions</caption>
+*  <tr><th>A / B
+*  <tr><td>rocsparse_datatype_f16_r
+*  <tr><td>rocsparse_datatype_f32_r
+*  <tr><td>rocsparse_datatype_f64_r
+*  <tr><td>rocsparse_datatype_f32_c
+*  <tr><td>rocsparse_datatype_f64_c
+*  </table>
 *
 *  \note
 *  This function writes the required allocation size (in bytes) to \p buffer_size and

--- a/library/include/internal/generic/rocsparse_sddmm.h
+++ b/library/include/internal/generic/rocsparse_sddmm.h
@@ -212,6 +212,7 @@ rocsparse_status rocsparse_sddmm_preprocess(rocsparse_handle            handle,
 *  <caption id="sddmm_mixed">Mixed Precisions</caption>
 *  <tr><th>A / B                    <th>C                        <th>compute_type
 *  <tr><td>rocsparse_datatype_f16_r <td>rocsparse_datatype_f32_r <td>rocsparse_datatype_f32_r
+*  <tr><td>rocsparse_datatype_f16_r <td>rocsparse_datatype_f16_r <td>rocsparse_datatype_f32_r
 *  </table>
 *
 *  \note

--- a/library/include/internal/generic/rocsparse_sparse_to_dense.h
+++ b/library/include/internal/generic/rocsparse_sparse_to_dense.h
@@ -64,11 +64,22 @@ extern "C" {
 *  Currently, \p rocsparse_sparse_to_dense only supports the algorithm \ref rocsparse_sparse_to_dense_alg_default. 
 *  See full example below.
 *
-*  \p rocsparse_sparse_to_dense supports \ref rocsparse_datatype_f32_r, \ref rocsparse_datatype_f64_r, 
+*  \p rocsparse_sparse_to_dense supports \ref rocsparse_datatype_f16_r, \ref rocsparse_datatype_f32_r, \ref rocsparse_datatype_f64_r, 
 *  \ref rocsparse_datatype_f32_c, and \ref rocsparse_datatype_f64_c for values arrays in the sparse matrix 
 *  (stored in CSR, CSC, or COO format) and the dense matrix. For the row/column offset and row/column index arrays of the 
 *  sparse matrix, \p rocsparse_sparse_to_dense supports the precisions \ref rocsparse_indextype_i32 and 
 *  \ref rocsparse_indextype_i64.
+*
+*  \par Uniform Precisions:
+*  <table>
+*  <caption id="sparse_to_dense_uniform">Uniform Precisions</caption>
+*  <tr><th>A / B
+*  <tr><td>rocsparse_datatype_f16_r
+*  <tr><td>rocsparse_datatype_f32_r
+*  <tr><td>rocsparse_datatype_f64_r
+*  <tr><td>rocsparse_datatype_f32_c
+*  <tr><td>rocsparse_datatype_f64_c
+*  </table>
 *
 *  \note
 *  This function writes the required allocation size (in bytes) to \p buffer_size and


### PR DESCRIPTION
Summary of proposed changes:
-  Add missing half precisions to Axpby, SparseToDense, DenseToSparse, and SDDMM documentation
