### PR TITLE
Adding an option to enable the fallback algorithm mechanism in v2_spmv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Documentation for rocSPARSE is available at
 
 ### Added
 * Adds `SpGEAM` generic routine for computing sparse matrix addition in CSR format
-* Adds `v2_SpMV` generic routine for computing sparse matrix vector multiplication. As opposed to the deprecated `rocsparse_spmv` routine, this routine does not use a fallback algorithm if a non-implemented configuration is encountered and will return an error in such a case. For the deprecated routine `rocsparse_spmv`, the user can enable warning messages in situations where a fallback algorithm is used by either calling upfront the routine `rocsparse_enable_debug` or exporting the variable `ROCSPARSE_DEBUG` (with the shell command `export ROCSPARSE_DEBUG=1`).
+* Adds `v2_SpMV` generic routine for computing sparse matrix vector multiplication. As opposed to the deprecated `rocsparse_spmv` routine, by default this routine does not use a fallback algorithm if a non-implemented configuration is encountered and will return an error in such a case. However, the user can enable the use of a fallback algorithm by setting the property `rocsparse_spmv_input_alg_fallback` with the routine `rocsparse_spmv_set_input`. For the deprecated routine `rocsparse_spmv`, the user can enable warning messages in situations where a fallback algorithm is used by either calling upfront the routine `rocsparse_enable_debug` or exporting the variable `ROCSPARSE_DEBUG` (with the shell command `export ROCSPARSE_DEBUG=1`).
 
 ### Removed
 

--- a/library/include/rocsparse-types.h
+++ b/library/include/rocsparse-types.h
@@ -696,10 +696,11 @@ typedef enum rocsparse_check_spmat_stage_
  */
 typedef enum rocsparse_spmv_input_
 {
-    rocsparse_spmv_input_alg, /**< Select algorithm for input on SpMV descriptor. */
-    rocsparse_spmv_input_operation, /**< Select matrix transpose operation for input on SpMV descriptor. */
-    rocsparse_spmv_input_scalar_datatype, /**< Select scalar  datatype for input on SpMV descriptor. */
-    rocsparse_spmv_input_compute_datatype /**< Select compute datatype for input on SpMV descriptor. */
+    rocsparse_spmv_input_alg, /**< Select algorithm for input on SpMV descriptor, the value type must be \ref rocsparse_spmv_alg (required). */
+    rocsparse_spmv_input_operation, /**< Select matrix transpose operation for input on SpMV descriptor, the value type must be \ref rocsparse_operation (required). */
+    rocsparse_spmv_input_scalar_datatype, /**< Select scalar  datatype for input on SpMV descriptor, the value type must be \ref rocsparse_datatype (required). */
+    rocsparse_spmv_input_compute_datatype, /**< Select compute datatype for input on SpMV descriptor, the value type must be \ref rocsparse_datatype (required). */
+    rocsparse_spmv_input_alg_fallback /**< Enable a fallback algorithm for input on SpMV descriptor, the value type must be int32_t or int64_t (optional, default is 0). */
 } rocsparse_spmv_input;
 
 /*! \ingroup types_module

--- a/library/src/conversion/rocsparse_convert_scalar.hpp
+++ b/library/src/conversion/rocsparse_convert_scalar.hpp
@@ -94,7 +94,7 @@ namespace rocsparse
 
     template <uint32_t BLOCKSIZE, typename F, typename... P>
     __launch_bounds__(BLOCKSIZE) __global__
-        inline void convert_device_scalars_kernel(F f, const void* source, void* target, P... p)
+        static void convert_device_scalars_kernel(F f, const void* source, void* target, P... p)
     {
         const size_t tid = hipBlockIdx_x * BLOCKSIZE + hipThreadIdx_x;
         convert_device_scalars_kernel_device(f, tid, source, target, p...);

--- a/library/src/level2/rocsparse_v2_spmv.cpp
+++ b/library/src/level2/rocsparse_v2_spmv.cpp
@@ -44,6 +44,7 @@ inline bool rocsparse::enum_utils::is_invalid(rocsparse_spmv_input value_)
     case rocsparse_spmv_input_operation:
     case rocsparse_spmv_input_compute_datatype:
     case rocsparse_spmv_input_scalar_datatype:
+    case rocsparse_spmv_input_alg_fallback:
     {
         return false;
     }
@@ -74,15 +75,27 @@ protected:
     rocsparse_datatype      m_scalar_datatype;
     rocsparse_datatype      m_compute_datatype;
 
-    float m_local_host_alpha_value[4];
-    float m_local_host_beta_value[4];
+    float m_local_host_alpha_value[4]{};
+    float m_local_host_beta_value[4]{};
 
     rocsparse_csrmv_info m_csrmv_info{};
     rocsparse_cscmv_info m_cscmv_info{};
     rocsparse_bsrmv_info m_bsrmv_info{};
 
+    bool m_fallback_algorithm{};
+
 public:
-    rocsparse_cscmv_info get_cscmv_info()
+    bool get_fallback_algorithm() const
+    {
+        return this->m_fallback_algorithm;
+    }
+
+    void set_fallback_algorithm(bool value)
+    {
+        this->m_fallback_algorithm = value;
+    }
+
+    rocsparse_cscmv_info get_cscmv_info() const
     {
         return this->m_cscmv_info;
     }
@@ -91,7 +104,7 @@ public:
         this->m_cscmv_info = value;
     }
 
-    rocsparse_csrmv_info get_csrmv_info()
+    rocsparse_csrmv_info get_csrmv_info() const
     {
         return this->m_csrmv_info;
     }
@@ -100,7 +113,7 @@ public:
         this->m_csrmv_info = value;
     }
 
-    rocsparse_bsrmv_info get_bsrmv_info()
+    rocsparse_bsrmv_info get_bsrmv_info() const
     {
         return this->m_bsrmv_info;
     }
@@ -112,14 +125,11 @@ public:
     ~_rocsparse_spmv_descr() = default;
 
     _rocsparse_spmv_descr()
-        : m_csrmv_info{}
-        , m_cscmv_info{}
-        , m_stage((rocsparse_v2_spmv_stage)-1)
+        : m_stage((rocsparse_v2_spmv_stage)-1)
         , m_alg((rocsparse_spmv_alg)-1)
         , m_operation((rocsparse_operation)-1)
         , m_scalar_datatype((rocsparse_datatype)-1)
         , m_compute_datatype((rocsparse_datatype)-1)
-
     {
     }
 
@@ -226,6 +236,41 @@ try
 
     switch(input)
     {
+
+    case rocsparse_spmv_input_alg_fallback:
+    {
+        switch(descr->get_stage())
+        {
+        case rocsparse_v2_spmv_stage_analysis:
+        case rocsparse_v2_spmv_stage_compute:
+        {
+            RETURN_WITH_MESSAGE_IF_ROCSPARSE_ERROR(
+                rocsparse_status_internal_error,
+                "The field 'rocsparse_spmv_input_alg_fallback' must be set before the stage "
+                "'rocsparse_v2_spmv_stage_analysis' is executed.");
+        }
+        }
+
+        ROCSPARSE_CHECKARG(
+            4,
+            size_in_bytes,
+            ((size_in_bytes != sizeof(int32_t)) && (size_in_bytes != sizeof(int64_t))),
+            rocsparse_status_invalid_size);
+
+        if(size_in_bytes == sizeof(int32_t))
+        {
+            const int32_t value = *reinterpret_cast<const int32_t*>(in);
+            descr->set_fallback_algorithm((value == 0) ? false : true);
+        }
+        else if(size_in_bytes == sizeof(int64_t))
+        {
+            const int64_t value = *reinterpret_cast<const int64_t*>(in);
+            descr->set_fallback_algorithm((value == 0) ? false : true);
+        }
+
+        return rocsparse_status_success;
+    }
+
     case rocsparse_spmv_input_alg:
     {
 
@@ -486,7 +531,7 @@ namespace rocsparse
 
         case rocsparse_v2_spmv_stage_compute:
         {
-            static constexpr bool    fallback_algorithm = false;
+            const bool               fallback_algorithm = spmv_descr->get_fallback_algorithm();
             const rocsparse_datatype scalar_datatype    = spmv_descr->get_scalar_datatype();
             const rocsparse_datatype compute_datatype   = spmv_descr->get_compute_datatype();
             const void*              local_alpha        = alpha;


### PR DESCRIPTION
Since we deprecate rocsparse_spmv, hipSPARSE must use rocsparse_v2_spmv instead.
To keep the parity behaviour of hipSPARSE with cuSPARSE, we need to enable the fallback algorithm in rocsparse_v2_spmv.

This mechanism is optional and disabled by default.
To enable the mechanism, the user needs to do the following:

rocsparse_spmv_descr spmv_descr;
...
int32_t fallback= 1;
rocsparse_spmv_set_input(handle, spmv_descr, rocsparse_spmv_input_alg_fallback, &fallback, sizeof(fallback));


