### PR TITLE
Change SpMV COO format default algorithm to use the atomic algorithm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Documentation for rocSPARSE is available at
 * Adds `SpGEAM` generic routine for computing sparse matrix addition in CSR format
 * Adds `v2_SpMV` generic routine for computing sparse matrix vector multiplication. As opposed to the deprecated `rocsparse_spmv` routine, this routine does not use a fallback algorithm if a non-implemented configuration is encountered and will return an error in such a case. For the deprecated routine `rocsparse_spmv`, the user can enable warning messages in situations where a fallback algorithm is used by either calling upfront the routine `rocsparse_enable_debug` or exporting the variable `ROCSPARSE_DEBUG` (with the shell command `export ROCSPARSE_DEBUG=1`).
 
+### Changed
+* For `rocsparse_spmv` and the newly added `rocsparse_v2_spmv` in COO format, the default algorithm has been changed to `rocsparse_spmv_alg_coo_atomic` from the previous `rocsparse_spmv_alg_coo_segmented`.
+
 ### Removed
 
 * The deprecated `rocsparse_spmv_ex` routine

--- a/library/src/level2/rocsparse_coomv_impl.cpp
+++ b/library/src/level2/rocsparse_coomv_impl.cpp
@@ -525,23 +525,6 @@ namespace rocsparse
         switch(alg)
         {
         case rocsparse_coomv_alg_default:
-        case rocsparse_coomv_alg_segmented:
-        {
-            RETURN_IF_ROCSPARSE_ERROR(rocsparse::coomv_segmented_dispatch(handle,
-                                                                          trans,
-                                                                          m,
-                                                                          n,
-                                                                          nnz,
-                                                                          alpha_device_host,
-                                                                          descr,
-                                                                          coo_val,
-                                                                          coo_row_ind,
-                                                                          coo_col_ind,
-                                                                          x,
-                                                                          beta_device_host,
-                                                                          y));
-            return rocsparse_status_success;
-        }
         case rocsparse_coomv_alg_atomic:
         {
             RETURN_IF_ROCSPARSE_ERROR(rocsparse::coomv_atomic_dispatch(handle,
@@ -557,6 +540,23 @@ namespace rocsparse
                                                                        x,
                                                                        beta_device_host,
                                                                        y));
+            return rocsparse_status_success;
+        }
+        case rocsparse_coomv_alg_segmented:
+        {
+            RETURN_IF_ROCSPARSE_ERROR(rocsparse::coomv_segmented_dispatch(handle,
+                                                                          trans,
+                                                                          m,
+                                                                          n,
+                                                                          nnz,
+                                                                          alpha_device_host,
+                                                                          descr,
+                                                                          coo_val,
+                                                                          coo_row_ind,
+                                                                          coo_col_ind,
+                                                                          x,
+                                                                          beta_device_host,
+                                                                          y));
             return rocsparse_status_success;
         }
         }


### PR DESCRIPTION
Summary of proposed changes:
- Change SpMV COO format default algorithm to use the atomic algorithm as it is generally faster
