### PR TITLE
Remove warnings in CI

### DIFF
--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -42,7 +42,7 @@ def runTestCommand (platform, project, gfilter, boolean rocmExamples=false, Stri
     if (platform.jenkinsLabel.contains('gfx90a'))
     {
         hmmTestCommand = """
-                            HSA_XNACK=0 GTEST_LISTENER=NO_PASS_LINE_IN_LOG  ./rocsparse-test  --rocsparse-enable-debug --rocsparse-clients-enable-test-debug-arguments --gtest_output=xml:test_detail_hmm_xnack_off.xml --gtest_color=yes --gtest_filter=${gfilter}-*known_bug*
+                            HSA_XNACK=0 GTEST_LISTENER=NO_PASS_LINE_IN_LOG ./rocsparse-test --gtest_output=xml:test_detail_hmm_xnack_off.xml --gtest_color=yes --gtest_filter=${gfilter}-*known_bug*
                             HSA_XNACK=1 GTEST_LISTENER=NO_PASS_LINE_IN_LOG ./rocsparse-test --gtest_output=xml:test_detail_hmm_xnack_on.xml --gtest_color=yes --gtest_filter=${gfilter}-*known_bug*
                          """
     }
@@ -52,7 +52,7 @@ def runTestCommand (platform, project, gfilter, boolean rocmExamples=false, Stri
                 cd ${project.paths.project_build_prefix}/build/${dirmode}/clients/staging
                 export LD_LIBRARY_PATH=/opt/rocm/lib/
                 ${centos7Workaround}
-                GTEST_LISTENER=NO_PASS_LINE_IN_LOG ./rocsparse-test --rocsparse-enable-debug --rocsparse-clients-enable-test-debug-arguments --gtest_output=xml --gtest_color=yes --gtest_filter=${gfilter}-*known_bug*
+                GTEST_LISTENER=NO_PASS_LINE_IN_LOG ./rocsparse-test --gtest_output=xml --gtest_color=yes --gtest_filter=${gfilter}-*known_bug*
                 ${hmmTestCommand}
             """
 
@@ -82,7 +82,7 @@ def runTestCommand (platform, project, gfilter, boolean rocmExamples=false, Stri
                         ctest --output-on-failure
                     done
                 """
-        platform.runCommand(this, testCommand, "ROCM Examples")  
+        platform.runCommand(this, testCommand, "ROCM Examples")
 
     }
 }
@@ -98,7 +98,7 @@ def runTestWithSanitizerCommand (platform, project, gfilter, String dirmode = "r
 		        export ASAN_LIB_PATH=\$(/opt/rocm/llvm/bin/clang -print-file-name=libclang_rt.asan-x86_64.so)
                 export LD_LIBRARY_PATH=\$LD_LIBRARY_PATH:\$(dirname "\${ASAN_LIB_PATH}")
                 ${centos7Workaround}
-                GTEST_LISTENER=NO_PASS_LINE_IN_LOG ASAN_SYMBOLIZER_PATH=/opt/rocm/llvm/bin/llvm-symbolizer ASAN_OPTIONS=detect_leaks=1 LSAN_OPTIONS=suppressions=../../../../suppr.txt ./rocsparse-test --rocsparse-enable-debug --rocsparse-clients-enable-test-debug-arguments --gtest_output=xml --gtest_color=yes --gtest_filter=${gfilter}-*known_bug*
+                GTEST_LISTENER=NO_PASS_LINE_IN_LOG ASAN_SYMBOLIZER_PATH=/opt/rocm/llvm/bin/llvm-symbolizer ASAN_OPTIONS=detect_leaks=1 LSAN_OPTIONS=suppressions=../../../../suppr.txt ./rocsparse-test --gtest_output=xml --gtest_color=yes --gtest_filter=${gfilter}-*known_bug*
             """
 
     platform.runCommand(this, command)

--- a/clients/common/rocsparse_parse_data.cpp
+++ b/clients/common/rocsparse_parse_data.cpp
@@ -1,6 +1,6 @@
 /*! \file */
 /* ************************************************************************
- * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2019-2025 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -264,48 +264,6 @@ bool rocsparse_parse_data(int& argc, char** argv, const std::string& default_fil
             }
             rocsparse_reproducibility_t::instance().config().set_info_level(r_level);
         }
-        else if(!strcmp(argv[i], "--rocsparse-clients-enable-test-debug-arguments"))
-        {
-            rocsparse_clients_envariables::set(rocsparse_clients_envariables::TEST_DEBUG_ARGUMENTS,
-                                               true);
-        }
-        else if(!strcmp(argv[i], "--rocsparse-clients-disable-test-debug-arguments"))
-        {
-            rocsparse_clients_envariables::set(rocsparse_clients_envariables::TEST_DEBUG_ARGUMENTS,
-                                               false);
-        }
-        else if(!strcmp(argv[i], "--rocsparse-disable-debug"))
-        {
-            rocsparse_disable_debug();
-        }
-        else if(!strcmp(argv[i], "--rocsparse-enable-debug"))
-        {
-            rocsparse_enable_debug();
-        }
-        else if(!strcmp(argv[i], "--rocsparse-enable-debug-verbose"))
-        {
-            rocsparse_enable_debug_verbose();
-        }
-        else if(!strcmp(argv[i], "--rocsparse-disable-debug-verbose"))
-        {
-            rocsparse_disable_debug_verbose();
-        }
-        else if(!strcmp(argv[i], "--rocsparse-enable-debug-arguments"))
-        {
-            rocsparse_enable_debug_arguments();
-        }
-        else if(!strcmp(argv[i], "--rocsparse-disable-debug-arguments"))
-        {
-            rocsparse_disable_debug_arguments();
-        }
-        else if(!strcmp(argv[i], "--rocsparse-enable-debug-arguments-verbose"))
-        {
-            rocsparse_enable_debug_arguments_verbose();
-        }
-        else if(!strcmp(argv[i], "--rocsparse-disable-debug-arguments-verbose"))
-        {
-            rocsparse_disable_debug_arguments_verbose();
-        }
         else
         {
             *argv_p++ = argv[i];
@@ -327,49 +285,6 @@ bool rocsparse_parse_data(int& argc, char** argv, const std::string& default_fil
                 std::cout << "--r-o        file results for reproducibility." << std::endl;
                 std::cout << "--r-level    level of information shrinking in the reproducibility "
                              "json file."
-                          << std::endl;
-                std::cout << "" << std::endl;
-                std::cout << "Rocsparse clients debug options:" << std::endl;
-                std::cout << "--rocsparse-clients-enable-test-debug-arguments   enable rocsparse "
-                             "clients test debug arguments, it discards any environment variable "
-                             "definition of ROCSPARSE_CLIENTS_TEST_DEBUG_ARGUMENTS."
-                          << std::endl;
-                std::cout << "--rocsparse-clients-disable-test-debug-arguments  disable rocsparse "
-                             "clients test debug arguments, it discards any environment variable "
-                             "definition of ROCSPARSE_CLIENTS_TEST_DEBUG_ARGUMENTS."
-                          << std::endl;
-                std::cout << "" << std::endl;
-                std::cout << "Rocsparse debug options:" << std::endl;
-                std::cout << "--rocsparse-enable-debug                     enable rocsparse debug, "
-                             "it discards any environment variable definition of ROCSPARSE_DEBUG."
-                          << std::endl;
-                std::cout
-                    << "--rocsparse-disable-debug                    disable rocsparse debug, it "
-                       "discards any environment variable definition of ROCSPARSE_DEBUG."
-                    << std::endl;
-                std::cout << "--rocsparse-enable-debug-verbose             enable rocsparse debug "
-                             "verbose, it discards any environment variable definition of "
-                             "ROCSPARSE_DEBUG_VERBOSE."
-                          << std::endl;
-                std::cout << "--rocsparse-disable-debug-verbose            disable rocsparse debug "
-                             "verbose, it discards any environment variable definition of "
-                             "ROCSPARSE_DEBUG_VERBOSE"
-                          << std::endl;
-                std::cout << "--rocsparse-enable-debug-arguments           enable rocsparse debug "
-                             "arguments, it discards any environment variable definition of "
-                             "ROCSPARSE_DEBUG_ARGUMENTS."
-                          << std::endl;
-                std::cout << "--rocsparse-disable-debug-arguments          disable rocsparse debug "
-                             "arguments, it discards any environment variable definition of "
-                             "ROCSPARSE_DEBUG_ARGUMENTS."
-                          << std::endl;
-                std::cout << "--rocsparse-enable-debug-arguments-verbose   enable rocsparse debug "
-                             "arguments verbose, it discards any environment variable definition "
-                             "of ROCSPARSE_DEBUG_ARGUMENTS_VERBOSE"
-                          << std::endl;
-                std::cout << "--rocsparse-disable-debug-arguments-verbose  disable rocsparse debug "
-                             "arguments verbose, it discards any environment variable definition "
-                             "of ROCSPARSE_DEBUG_ARGUMENTS_VERBOSE"
                           << std::endl;
                 std::cout << "" << std::endl;
                 std::cout << "" << std::endl;

--- a/clients/common/rocsparse_parse_data.cpp
+++ b/clients/common/rocsparse_parse_data.cpp
@@ -153,8 +153,62 @@ bool rocsparse_parse_data(int& argc, char** argv, const std::string& default_fil
     }
     const char* include_path = nullptr;
     rocsparse_reproducibility_t::instance().config().set_command(command);
+
+    //
+    // Disable debug argument verbose
+    //
+    {
+        static constexpr const char* option_force_debug_arguments_verbose
+            = "--force-debug-arguments-verbose";
+        bool enable_debug_arguments_verbose = false;
+        for(int iarg = 0; iarg < argc; ++iarg)
+        {
+            if(!strcmp(argv[iarg], option_force_debug_arguments_verbose))
+            {
+                enable_debug_arguments_verbose = true;
+                (void)memcpy(argv + iarg, argv + iarg + 1, (argc - iarg) * sizeof(char*));
+                argv[--argc] = nullptr;
+                break;
+            }
+        }
+
+        if(enable_debug_arguments_verbose == false)
+        {
+            rocsparse_disable_debug_arguments_verbose();
+            std::cout << "rocsparse-test: debug arguments verbose is disabled for testings (use "
+                      << option_force_debug_arguments_verbose << " to skip the disabling)"
+                      << std::endl;
+        }
+    }
+
+    //
+    // Disable debug warnings
+    //
+    {
+        static constexpr const char* option_force_warning  = "--force-warnings";
+        bool                         enable_debug_warnings = false;
+        for(int iarg = 0; iarg < argc; ++iarg)
+        {
+            if(!strcmp(argv[iarg], option_force_warning))
+            {
+                enable_debug_warnings = true;
+                (void)memcpy(argv + iarg, argv + iarg + 1, (argc - iarg) * sizeof(char*));
+                argv[--argc] = nullptr;
+                break;
+            }
+        }
+
+        if(enable_debug_warnings == false)
+        {
+            rocsparse_disable_debug_warnings();
+            std::cout << "rocsparse-test: warnings are disabled for testings (use "
+                      << option_force_warning << " to skip the disabling)" << std::endl;
+        }
+    }
+
     for(int i = 1; argv[i]; ++i)
     {
+
         if(!strcmp(argv[i], "-I"))
         {
             include_path = argv[++i];

--- a/clients/tests/rocsparse_test_main.cpp
+++ b/clients/tests/rocsparse_test_main.cpp
@@ -22,6 +22,7 @@
  *
  * ************************************************************************ */
 
+#include "rocsparse_clients_envariables.hpp"
 #include "rocsparse_parse_data.hpp"
 #include "rocsparse_reproducibility.hpp"
 #include "utility.hpp"
@@ -177,6 +178,44 @@ int main(int argc, char** argv)
     // Enable debug mode for testing.
     //
     rocsparse_enable_debug();
+
+    //
+    // Enable test debug arguments.
+    //
+    if(rocsparse_clients_envariables::is_defined(
+           rocsparse_clients_envariables::TEST_DEBUG_ARGUMENTS)
+       == false)
+    {
+        rocsparse_clients_envariables::set(rocsparse_clients_envariables::TEST_DEBUG_ARGUMENTS,
+                                           true);
+    }
+
+    //
+    // Disable debug argument verbose
+    //
+    {
+        static constexpr const char* option_force_debug_arguments_verbose
+            = "--force-debug-arguments-verbose";
+        bool enable_debug_arguments_verbose = false;
+        for(int iarg = 0; iarg < argc; ++iarg)
+        {
+            if(!strcmp(argv[iarg], option_force_debug_arguments_verbose))
+            {
+                enable_debug_arguments_verbose = true;
+                (void)memcpy(argv + iarg, argv + iarg + 1, (argc - iarg) * sizeof(char*));
+                argv[--argc] = nullptr;
+                break;
+            }
+        }
+
+        if(enable_debug_arguments_verbose == false)
+        {
+            rocsparse_disable_debug_arguments_verbose();
+            std::cout << "rocsparse-test: debug arguments verbose is disabled for testings (use "
+                      << option_force_debug_arguments_verbose << " to skip the disabling)"
+                      << std::endl;
+        }
+    }
 
     //
     // Disable debug warnings

--- a/clients/tests/rocsparse_test_main.cpp
+++ b/clients/tests/rocsparse_test_main.cpp
@@ -190,58 +190,6 @@ int main(int argc, char** argv)
                                            true);
     }
 
-    //
-    // Disable debug argument verbose
-    //
-    {
-        static constexpr const char* option_force_debug_arguments_verbose
-            = "--force-debug-arguments-verbose";
-        bool enable_debug_arguments_verbose = false;
-        for(int iarg = 0; iarg < argc; ++iarg)
-        {
-            if(!strcmp(argv[iarg], option_force_debug_arguments_verbose))
-            {
-                enable_debug_arguments_verbose = true;
-                (void)memcpy(argv + iarg, argv + iarg + 1, (argc - iarg) * sizeof(char*));
-                argv[--argc] = nullptr;
-                break;
-            }
-        }
-
-        if(enable_debug_arguments_verbose == false)
-        {
-            rocsparse_disable_debug_arguments_verbose();
-            std::cout << "rocsparse-test: debug arguments verbose is disabled for testings (use "
-                      << option_force_debug_arguments_verbose << " to skip the disabling)"
-                      << std::endl;
-        }
-    }
-
-    //
-    // Disable debug warnings
-    //
-    {
-        static constexpr const char* option_force_warning  = "--force-warnings";
-        bool                         enable_debug_warnings = false;
-        for(int iarg = 0; iarg < argc; ++iarg)
-        {
-            if(!strcmp(argv[iarg], option_force_warning))
-            {
-                enable_debug_warnings = true;
-                (void)memcpy(argv + iarg, argv + iarg + 1, (argc - iarg) * sizeof(char*));
-                argv[--argc] = nullptr;
-                break;
-            }
-        }
-
-        if(enable_debug_warnings == false)
-        {
-            rocsparse_disable_debug_warnings();
-            std::cout << "rocsparse-test: warnings are disabled for testings (use "
-                      << option_force_warning << " to skip the disabling)" << std::endl;
-        }
-    }
-
     // Get version
     rocsparse_handle handle;
     rocsparse_status status = rocsparse_create_handle(&handle);

--- a/clients/tests/rocsparse_test_main.cpp
+++ b/clients/tests/rocsparse_test_main.cpp
@@ -173,6 +173,36 @@ public:
 
 int main(int argc, char** argv)
 {
+    //
+    // Enable debug mode for testing.
+    //
+    rocsparse_enable_debug();
+
+    //
+    // Disable debug warnings
+    //
+    {
+        static constexpr const char* option_force_warning  = "--force-warnings";
+        bool                         enable_debug_warnings = false;
+        for(int iarg = 0; iarg < argc; ++iarg)
+        {
+            if(!strcmp(argv[iarg], option_force_warning))
+            {
+                enable_debug_warnings = true;
+                (void)memcpy(argv + iarg, argv + iarg + 1, (argc - iarg) * sizeof(char*));
+                argv[--argc] = nullptr;
+                break;
+            }
+        }
+
+        if(enable_debug_warnings == false)
+        {
+            rocsparse_disable_debug_warnings();
+            std::cout << "rocsparse-test: warnings are disabled for testings (use "
+                      << option_force_warning << " to skip the disabling)" << std::endl;
+        }
+    }
+
     // Get version
     rocsparse_handle handle;
     rocsparse_status status = rocsparse_create_handle(&handle);

--- a/clients/tests/test.hpp
+++ b/clients/tests/test.hpp
@@ -1,6 +1,6 @@
 /*! \file */
 /* ************************************************************************
-* Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights Reserved.
+* Copyright (C) 2022-2025 Advanced Micro Devices, Inc. All rights Reserved.
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
@@ -178,16 +178,7 @@ inline void testing_reproducibility(const Arguments& arg, F test_execute)
         static void testing_bad_arg(const Arguments& arg)                                         \
         {                                                                                         \
             test_check::reset_auto_testing_bad_arg();                                             \
-            const int state_debug_arguments_verbose = rocsparse_state_debug_arguments_verbose();  \
-            if(state_debug_arguments_verbose == 1)                                                \
-            {                                                                                     \
-                rocsparse_disable_debug_arguments_verbose();                                      \
-            }                                                                                     \
             testing_##ROUTINE##_bad_arg<P...>(arg);                                               \
-            if(state_debug_arguments_verbose == 1)                                                \
-            {                                                                                     \
-                rocsparse_enable_debug_arguments_verbose();                                       \
-            }                                                                                     \
             if(false && false == test_check::did_auto_testing_bad_arg())                          \
             {                                                                                     \
                 std::cerr << "rocsparse_test warning testing bad arguments of "                   \

--- a/library/include/rocsparse-auxiliary.h
+++ b/library/include/rocsparse-auxiliary.h
@@ -2644,7 +2644,7 @@ int rocsparse_state_debug();
 
 /*! \ingroup aux_module
    *  \brief Enable debug warnings
-   * \details If the debug warnings is enabled, then some specific warnings could be printed at the execution.
+   * \details If the debug warnings are enabled, then some specific warnings could be printed during the execution.
    *  \note This routine ignores the environment variable ROCSPARSE_DEBUG_WARNINGS.
    */
 ROCSPARSE_EXPORT

--- a/library/include/rocsparse-auxiliary.h
+++ b/library/include/rocsparse-auxiliary.h
@@ -2634,12 +2634,28 @@ void rocsparse_enable_debug();
    */
 ROCSPARSE_EXPORT
 void rocsparse_disable_debug();
+
 /*! \ingroup aux_module
    * \brief Get state of  debug.
    * \return 1 if enabled, 0 otherwise.
    */
 ROCSPARSE_EXPORT
 int rocsparse_state_debug();
+
+/*! \ingroup aux_module
+   *  \brief Enable debug warnings
+   * \details If the debug warnings is enabled, then some specific warnings could be printed at the execution.
+   *  \note This routine ignores the environment variable ROCSPARSE_DEBUG_WARNINGS.
+   */
+ROCSPARSE_EXPORT
+void rocsparse_enable_debug_warnings();
+
+/*! \ingroup aux_module
+   *  \brief Disable debug warnings
+   *  \note This routine ignores the environment variable ROCSPARSE_DEBUG_WARNINGS.
+   */
+ROCSPARSE_EXPORT
+void rocsparse_disable_debug_warnings();
 
 /*! \ingroup aux_module
    *  \brief Enable debug verbose.

--- a/library/src/include/debug.h
+++ b/library/src/include/debug.h
@@ -1,6 +1,6 @@
 /*! \file */
 /* ************************************************************************
- * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -41,6 +41,7 @@ namespace rocsparse
         bool debug_arguments_verbose;
         bool debug_kernel_launch;
         bool debug_force_host_assert;
+        bool debug_warnings;
 
     public:
         bool get_debug() const;
@@ -49,6 +50,7 @@ namespace rocsparse
         bool get_debug_arguments() const;
         bool get_debug_arguments_verbose() const;
         bool get_debug_force_host_assert() const;
+        bool get_debug_warnings() const;
 
         void set_debug(bool value);
         void set_debug_verbose(bool value);
@@ -56,6 +58,7 @@ namespace rocsparse
         void set_debug_kernel_launch(bool value);
         void set_debug_arguments_verbose(bool value);
         void set_debug_force_host_assert(bool value);
+        void set_debug_warnings(bool value);
     };
 
     struct debug_st
@@ -104,6 +107,11 @@ namespace rocsparse
                     rocsparse::envariables::names[rocsparse::envariables::DEBUG_FORCE_HOST_ASSERT]))
                     ? debug
                     : ROCSPARSE_ENVARIABLES.get(rocsparse::envariables::DEBUG_FORCE_HOST_ASSERT));
+
+            m_var.set_debug_verbose(
+                (!getenv(rocsparse::envariables::names[rocsparse::envariables::DEBUG_WARNINGS]))
+                    ? debug
+                    : ROCSPARSE_ENVARIABLES.get(rocsparse::envariables::DEBUG_WARNINGS));
 
             const bool debug_kernel_launch
                 = ROCSPARSE_ENVARIABLES.get(rocsparse::envariables::DEBUG_KERNEL_LAUNCH);

--- a/library/src/include/envariables.h
+++ b/library/src/include/envariables.h
@@ -55,7 +55,8 @@ namespace rocsparse
     ENVARIABLE(MEMSTAT_FORCE_MANAGED)   \
     ENVARIABLE(DEBUG_FORCE_HOST_ASSERT) \
     ENVARIABLE(MEMSTAT_GUARDS)          \
-    ENVARIABLE(ROCTX)
+    ENVARIABLE(ROCTX)                   \
+    ENVARIABLE(DEBUG_WARNINGS)
 
         //
         // Specification of the enum and the array of all values.

--- a/library/src/rocsparse_debug.cpp
+++ b/library/src/rocsparse_debug.cpp
@@ -59,6 +59,11 @@ bool rocsparse::debug_variables_st::get_debug_arguments() const
     return this->debug_arguments;
 }
 
+bool rocsparse::debug_variables_st::get_debug_warnings() const
+{
+    return this->debug_warnings;
+}
+
 bool rocsparse::debug_variables_st::get_debug_arguments_verbose() const
 {
     return this->debug_arguments_verbose;
@@ -80,6 +85,16 @@ void rocsparse::debug_variables_st::set_debug_verbose(bool value)
     {
         s_mutex.lock();
         this->debug_verbose = value;
+        s_mutex.unlock();
+    }
+}
+
+void rocsparse::debug_variables_st::set_debug_warnings(bool value)
+{
+    if(value != this->debug_warnings)
+    {
+        s_mutex.lock();
+        this->debug_warnings = value;
         s_mutex.unlock();
     }
 }
@@ -156,6 +171,16 @@ int rocsparse_state_debug()
     return rocsparse_debug_variables.get_debug() ? 1 : 0;
 }
 
+void rocsparse_enable_debug_warnings()
+{
+    rocsparse_debug_variables.set_debug_warnings(true);
+}
+
+void rocsparse_disable_debug_warnings()
+{
+    rocsparse_debug_variables.set_debug_warnings(false);
+}
+
 void rocsparse_enable_debug_arguments_verbose()
 {
     rocsparse_debug_variables.set_debug_arguments_verbose(true);
@@ -192,12 +217,14 @@ void rocsparse_enable_debug_verbose()
 {
     rocsparse_debug_variables.set_debug_verbose(true);
     rocsparse_enable_debug_arguments_verbose();
+    rocsparse_enable_debug_warnings();
 }
 
 void rocsparse_disable_debug_verbose()
 {
     rocsparse_debug_variables.set_debug_verbose(false);
     rocsparse_disable_debug_arguments_verbose();
+    rocsparse_disable_debug_warnings();
 }
 
 void rocsparse_enable_debug_force_host_assert()

--- a/library/src/rocsparse_message.cpp
+++ b/library/src/rocsparse_message.cpp
@@ -1,7 +1,7 @@
 /*! \file */
 
 /* ************************************************************************
- * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -44,7 +44,7 @@ void rocsparse::warning_message(const char* msg_,
                                 const char* file_,
                                 int         line_)
 {
-    if(rocsparse_debug_variables.get_debug_verbose())
+    if(rocsparse_debug_variables.get_debug_warnings())
     {
         std::cout << "// rocSPARSE.warning: { \"function\": \"" << function_ << "\"," << std::endl
                   << "//                      \"line\"    : \"" << line_ << "\"," << std::endl


### PR DESCRIPTION
CI log files are polluted with warnings triggered by the code execution in debug mode, e.g., warnings from spmv for algorithm fallbacks. 
These warnings are disabled when testing with the rocsparse-test executable. 
An option called "--force-warnings" is available to skip the disabling. 

Cleanup has been done on the options of the executable rocsparse-test.

