### PR TITLE
Fixing stress tests for coomv.

### DIFF
--- a/clients/tests/test_spmv_coo.yaml
+++ b/clients/tests/test_spmv_coo.yaml
@@ -256,7 +256,7 @@ Tests:
   baseA: [rocsparse_index_base_zero]
   matrix: [rocsparse_matrix_pentadiagonal]
   storage: [rocsparse_storage_mode_sorted]
-  spmv_alg: [rocsparse_spmv_alg_coo]
+  spmv_alg: [rocsparse_spmv_alg_coo, rocsparse_spmv_alg_coo_atomic]
 
 #
 # mixed precision

--- a/clients/tests/test_v2_spmv_coo.yaml
+++ b/clients/tests/test_v2_spmv_coo.yaml
@@ -254,7 +254,7 @@ Tests:
   baseA: [rocsparse_index_base_zero]
   matrix: [rocsparse_matrix_pentadiagonal]
   storage: [rocsparse_storage_mode_sorted]
-  spmv_alg: [rocsparse_spmv_alg_coo]
+  spmv_alg: [rocsparse_spmv_alg_coo, rocsparse_spmv_alg_coo_atomic]
 
 #
 # mixed precision

--- a/library/src/level2/rocsparse_coomv_impl.cpp
+++ b/library/src/level2/rocsparse_coomv_impl.cpp
@@ -191,11 +191,11 @@ rocsparse_status rocsparse::coomv_analysis_template(rocsparse_handle          ha
     case rocsparse_coomv_alg_default:
     case rocsparse_coomv_alg_segmented:
     {
-        break;
+        return rocsparse_status_success;
     }
     case rocsparse_coomv_alg_atomic:
     {
-        return rocsparse_status_success;
+        break;
     }
     }
 
@@ -222,7 +222,7 @@ rocsparse_status rocsparse::coomv_analysis_template(rocsparse_handle          ha
     {
     case rocsparse_operation_none:
     {
-        if(std::is_same<I, int32_t>() && nnz < std::numeric_limits<int32_t>::max())
+        if(std::is_same<I, int32_t>() && nnz <= std::numeric_limits<int32_t>::max())
         {
             I* max_nnz     = nullptr;
             I* csr_row_ptr = nullptr;
@@ -259,11 +259,11 @@ rocsparse_status rocsparse::coomv_analysis_template(rocsparse_handle          ha
             int64_t* max_nnz     = nullptr;
             int64_t* csr_row_ptr = nullptr;
             RETURN_IF_HIP_ERROR(
-                rocsparse_hipMallocAsync((void**)&max_nnz, sizeof(I), handle->stream));
+                rocsparse_hipMallocAsync(&max_nnz, sizeof(int64_t), handle->stream));
 
-            RETURN_IF_HIP_ERROR(rocsparse_hipMallocAsync(
-                (void**)&csr_row_ptr, sizeof(int64_t) * (m + 1), handle->stream));
-            RETURN_IF_HIP_ERROR(hipMemsetAsync(max_nnz, 0, sizeof(I), handle->stream));
+            RETURN_IF_HIP_ERROR(
+                rocsparse_hipMallocAsync(&csr_row_ptr, sizeof(int64_t) * (m + 1), handle->stream));
+            RETURN_IF_HIP_ERROR(hipMemsetAsync(max_nnz, 0, sizeof(int64_t), handle->stream));
 
             RETURN_IF_ROCSPARSE_ERROR(
                 rocsparse::coo2csr_template(handle, coo_row_ind, nnz, m, csr_row_ptr, descr->base));
@@ -278,9 +278,11 @@ rocsparse_status rocsparse::coomv_analysis_template(rocsparse_handle          ha
                 csr_row_ptr,
                 max_nnz);
 
-            int64_t local_max_nnz;
-            RETURN_IF_HIP_ERROR(hipMemcpyAsync(
-                &local_max_nnz, max_nnz, sizeof(int64_t), hipMemcpyDeviceToHost, handle->stream));
+            RETURN_IF_HIP_ERROR(hipMemcpyAsync(&descr->max_nnz_per_row,
+                                               max_nnz,
+                                               sizeof(int64_t),
+                                               hipMemcpyDeviceToHost,
+                                               handle->stream));
             RETURN_IF_HIP_ERROR(hipStreamSynchronize(handle->stream));
 
             RETURN_IF_HIP_ERROR(rocsparse_hipFreeAsync(max_nnz, handle->stream));


### PR DESCRIPTION
The algorithm "atomic" skipped the analysis, but it wasn't supposed to.
The algorithm "segmented" applied the analysis, but it wasn't supposed to.
The stress test tested the algorithm as "segmented" only, and since it applied the analysis, it has shown a bug in the analysis for large matrices.

Stress tests are now applied to both algorithms, and the analysis is fixed for large matrices.

