### PR TITLE
Adapt ifdefs to generic architectures

### DIFF
--- a/library/src/level2/csrmv_device.h
+++ b/library/src/level2/csrmv_device.h
@@ -497,10 +497,7 @@ namespace rocsparse
                 // To force the compiler to stick to the order of operations, we need acquire/release fences.
                 // Workgroup scope is sufficient for this purpose, to only invalidate L1 and avoid L2
                 // invalidations.
-#if defined(__gfx1200__) || defined(__gfx1201__)
-#define __gfx12__
-#endif
-#if defined(__gfx12__)
+#if defined(__GFX12__)
                 __threadfence();
 #else
                 __builtin_amdgcn_fence(__ATOMIC_RELEASE, "workgroup");
@@ -1047,10 +1044,7 @@ namespace rocsparse
             // To force the compiler to stick to the order of operations, we need acquire/release fences.
             // Workgroup scope is sufficient for this purpose, to only invalidate L1 and avoid L2
             // invalidations.
-#if defined(__gfx1200__) || defined(__gfx1201__)
-#define __gfx12__
-#endif
-#if defined(__gfx12__)
+#if defined(__GFX12__)
             __threadfence();
 #else
             __builtin_amdgcn_fence(__ATOMIC_RELEASE, "workgroup");


### PR DESCRIPTION
I was thinking about building with e.g. `GPU_TARGETS="gfx12-generic"` (see https://rocm.docs.amd.com/projects/llvm-project/en/develop/conceptual/code-portability.html#generic-code-objects) to reduce compile time and binary size while still being able to run on all architectures relevant to me. This led me to a few `#ifdef`s that explicitly checked for specific architecture, which this pull request adapts to also support generic architectures.

I've opened a similar pull request for rocBLAS at https://github.com/ROCm/rocBLAS/pull/1624.