### PR TITLE
Docs: Add environment variable reference page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -44,6 +44,7 @@ For ROCm code examples, see `<https://github.com/ROCm/rocm-examples>`_.
     * :ref:`api`
     * :ref:`rocsparse_types_`
     * :ref:`rocsparse_precision_support_`
+    * :ref:`rocsparse_environment_variables_`
     * :ref:`rocsparse_enumerations_`
     * :ref:`rocsparse_auxiliary_functions_`
     * :ref:`rocsparse_level1_functions_`

--- a/docs/reference/env_variables.rst
+++ b/docs/reference/env_variables.rst
@@ -1,0 +1,57 @@
+.. meta::
+  :description: rocSPARSE environment variables reference
+  :keywords: rocSPARSE, ROCm, API, environment variables, environment, reference
+
+.. _rocsparse_environment_variables_:
+
+********************************************************************
+rocSPARSE environment variables
+********************************************************************
+
+This section describes the important rocSPARSE environment variables,
+which are grouped by functionality.
+
+Logging variables
+================================================================================
+
+The logging environment variables for rocSPARSE are collected in the following table.
+For more information, see :ref:`rocsparse_logging`.
+
+.. list-table::
+    :header-rows: 1
+    :widths: 35,14,51
+
+    * - **Environment variable**
+      - **Default value**
+      - **Value**
+
+    * - | ``ROCSPARSE_LAYER``
+        | Bit mask that enables logging modes.
+      - Unset by default.
+      - | Bitwise OR of zero or more bit masks:
+        | 0: No logging (if not set)
+        | 1: Trace logging
+        | 2: Bench logging
+        | 3: Trace and bench logging
+        | 4: Debug logging
+        | 5: Trace and debug logging
+        | 6: Bench and debug logging
+        | 7: Trace, bench, and debug logging
+
+    * - | ``ROCSPARSE_LOG_TRACE_PATH``
+        | Specifies path and file name to capture trace logging output.
+      - stderr output
+      - | Full path name for trace log files.
+        | If not set or file cannot be opened, output streams to stderr.
+
+    * - | ``ROCSPARSE_LOG_BENCH_PATH``
+        | Specifies path and file name to capture bench logging output.
+      - stderr output
+      - | Full path name for bench log files.
+        | If not set or file cannot be opened, output streams to stderr.
+
+    * - | ``ROCSPARSE_LOG_DEBUG_PATH``
+        | Specifies path and file name to capture debug logging output.
+      - stderr output
+      - | Full path name for debug log files.
+        | If not set or file cannot be opened, output streams to stderr.

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -31,6 +31,7 @@ subtrees:
       - file: reference/api.rst
       - file: reference/types.rst
       - file: reference/precision.rst
+      - file: reference/env_variables.rst
       - file: reference/enumerations.rst
       - file: reference/auxiliary.rst
       - file: reference/level1.rst


### PR DESCRIPTION
This is part of the environment variable initiative, where we aim to create a ROCm environment variable index page that contains the links to every component's environment variable page. Do let me know if there are any other environment variables besides the one that is listed, and whether the description/default values are correct.

Summary of proposed changes:
- Create a reference environment variable page, allows for future environment variables to be added to a common page
-
-
