### PR TITLE
Change to runtime deprecation warning on csritilu0 (enum)

### DIFF
--- a/library/include/rocsparse-types.h
+++ b/library/include/rocsparse-types.h
@@ -635,7 +635,7 @@ typedef enum rocsparse_itilu0_alg_
     = 2, /**< ASynchronous ITILU0 algorithm with explicit storage splitting */
     rocsparse_itilu0_alg_sync_split
     = 3, /**< Synchronous ITILU0 algorithm with explicit storage splitting */
-    rocsparse_itilu0_alg_sync_split_fusion [[deprecated]]
+    rocsparse_itilu0_alg_sync_split_fusion
     = 4 /**< Semi-synchronous ITILU0 algorithm with explicit storage splitting */
 } rocsparse_itilu0_alg;
 

--- a/library/include/rocsparse-types.h
+++ b/library/include/rocsparse-types.h
@@ -636,7 +636,7 @@ typedef enum rocsparse_itilu0_alg_
     rocsparse_itilu0_alg_sync_split
     = 3, /**< Synchronous ITILU0 algorithm with explicit storage splitting */
     rocsparse_itilu0_alg_sync_split_fusion
-    = 4 /**< Semi-synchronous ITILU0 algorithm with explicit storage splitting */
+    = 4 /**< This algorithm is deprecated and will be removed in a future release */
 } rocsparse_itilu0_alg;
 
 /*! \ingroup types_module

--- a/library/src/include/message.h
+++ b/library/src/include/message.h
@@ -47,9 +47,13 @@ namespace rocsparse
                        const char*      file_,
                        int              line_);
 
+    // Deprecation message
+    void deprecation_message(const char* function_);
+
 #define ROCSPARSE_MESSAGE(MESSAGE__) rocsparse::message(MESSAGE__, __FUNCTION__, __FILE__, __LINE__)
 #define ROCSPARSE_WARNING_MESSAGE(MESSAGE__) \
     rocsparse::warning_message(MESSAGE__, __FUNCTION__, __FILE__, __LINE__)
 #define ROCSPARSE_ERROR_MESSAGE(STATUS__, MESSAGE__) \
     rocsparse::error_message(STATUS__, MESSAGE__, __FUNCTION__, __FILE__, __LINE__)
+#define ROCSPARSE_DEPRECATION_MESSAGE(FUNCTION__) rocsparse::deprecation_message(FUNCTION__)
 }

--- a/library/src/precond/itilu0/rocsparse_csritilu0x_preprocess.cpp
+++ b/library/src/precond/itilu0/rocsparse_csritilu0x_preprocess.cpp
@@ -55,6 +55,7 @@ namespace rocsparse
         }
         case rocsparse_itilu0_alg_sync_split_fusion:
         {
+            ROCSPARSE_DEPRECATION_MESSAGE("rocsparse_itilu0_alg_sync_split_fusion");
             RETURN_IF_ROCSPARSE_ERROR(
                 (rocsparse::csritilu0x_driver_t<
                     rocsparse_itilu0_alg_sync_split_fusion>::preprocess<I, J>::run(parameters...)));

--- a/library/src/rocsparse_message.cpp
+++ b/library/src/rocsparse_message.cpp
@@ -70,8 +70,8 @@ void rocsparse::error_message(
 
 void rocsparse::deprecation_message(const char* function_)
 {
-    std::cout << "// rocSPARSE.deprecated:  { \"function\": \"" << function_ <<"\","
-              << std::endl
-              << "//                          \"msg\"     : \"will be removed in a future release\" }"
-              << std::endl;
+    std::cout
+        << "// rocSPARSE.deprecated:  { \"function\": \"" << function_ << "\"," << std::endl
+        << "//                          \"msg\"     : \"will be removed in a future release\" }"
+        << std::endl;
 }

--- a/library/src/rocsparse_message.cpp
+++ b/library/src/rocsparse_message.cpp
@@ -67,3 +67,11 @@ void rocsparse::error_message(
                   << std::endl;
     }
 }
+
+void rocsparse::deprecation_message(const char* function_)
+{
+    std::cout << "// rocSPARSE.deprecated:  { \"function\": \"" << function_ <<"\","
+              << std::endl
+              << "//                          \"msg\"     : \"will be removed in a future release\" }"
+              << std::endl;
+}


### PR DESCRIPTION
This PR fixes the deprecation spam by changing from compiler to runtime deprecation warning for the deprecated csritilu0 enum entry.
I didnt find it very useful to hit the warning by just including the rocsparse header.

I placed the runtime warning in the preprocess function, to avoid spam when using the compute function multiple times.

This is how it looks in e.g. rocALUTION when using the deprecated enum:
```
$ ./clients/staging/itsolve matrix.mtx 
Number of CPU cores: 64
Host thread affinity policy - thread mapping on every second core (avoiding HyperThreading)
Number of HIP devices in the system: 1
rocALUTION ver 4.0.0-cc95212-dirty
rocALUTION platform is initialized
Accelerator backend: HIP
OpenMP threads: 32
rocBLAS ver 4.4.0.80e5394d
rocSPARSE ver 3.5.0-ec6544e5-dirty
------------------------------------------------
Selected HIP device: 0
Device name: Radeon RX 7900 XT
totalGlobalMem: 20464 MByte
clockRate: 2025000
compute capability: 11.0
------------------------------------------------
MPI is not initialized
ReadFileMTX: filename=matrix.mtx; reading...
ReadFileMTX: filename=matrix.mtx; done
// rocSPARSE.deprecated:  { "function": "rocsparse_itilu0_alg_sync_split_fusion",
//                          "msg"     : "will be removed in a future release" }
           liter            iter            corr        residual             val            rate
              27               0     7.83334e-09     7.83334e-09     7.83334e-09               1
           liter            iter            corr        residual             val            rate
               1               1     4.15083e-09     4.15083e-09     4.15083e-09        0.887173
LocalMatrix name=matrix.mtx; rows=900; cols=900; nnz=7744; prec=64bit; format=CSR(32,32); host backend={CPU(OpenMP)}; accelerator backend={HIP}; current=HIP
Fixed Point Iteration solver starts with
ItILU0(SyncSplitFusion,Verbose,StoppingCriteria,ComputeNrmCorrection,ComputeNrmResidual,50,1e-08) preconditioner
ItILU0 nnz = 7744
TriSolverAlg = iterative (30, 1e-08)
IterationControl criteria: abs tol=1e-15; rel tol=1e-06; div tol=1e+08; max iter=1000000
IterationControl initial residual = 33.2866
IterationControl RELATIVE criteria has been reached: res norm=3.32127e-05; rel val=9.97778e-07; iter=143
Fixed Point Iteration solver ends
Solver execution:0.443417 sec
ItILU0::niter = 2
ItILU0::CorrectionNrm[0] = 7.83334e-09
ItILU0::CorrectionNrm[1] = 4.15083e-09
ItILU0::ResidualNrm[0] = 7.83334e-09
ItILU0::ResidualNrm[1] = 4.15083e-09
||e - x||_2 = 0.000540136
```