### PR TITLE
Fixing name and documentation for rocsparse_error.

### DIFF
--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -31,6 +31,10 @@ Auxiliary functions
 +-----------------------------------------------------+
 |:cpp:func:`rocsparse_get_git_rev`                    |
 +-----------------------------------------------------+
+|:cpp:func:`rocsparse_destroy_error`                  |
++-----------------------------------------------------+
+|:cpp:func:`rocsparse_error_get_message`              |
++-----------------------------------------------------+
 |:cpp:func:`rocsparse_create_mat_descr`               |
 +-----------------------------------------------------+
 |:cpp:func:`rocsparse_destroy_mat_descr`              |

--- a/docs/reference/auxiliary.rst
+++ b/docs/reference/auxiliary.rst
@@ -59,6 +59,16 @@ rocsparse_get_git_rev()
 
 .. doxygenfunction:: rocsparse_get_git_rev
 
+rocsparse_destroy_error()
+-------------------------
+
+.. doxygenfunction:: rocsparse_destroy_error
+
+rocsparse_error_get_message()
+-----------------------------
+
+.. doxygenfunction:: rocsparse_error_get_message
+
 rocsparse_create_mat_descr()
 ----------------------------
 

--- a/library/include/rocsparse-auxiliary.h
+++ b/library/include/rocsparse-auxiliary.h
@@ -100,7 +100,7 @@ rocsparse_status rocsparse_destroy_error(rocsparse_error error);
  *  \retval rocsparse_status_internal_error an internal error occurred.
  */
 ROCSPARSE_EXPORT
-const char* rocsparse_error_message(rocsparse_error error);
+const char* rocsparse_error_get_message(rocsparse_error error);
 
 /*! \ingroup aux_module
  *  \brief Return the string representation of a rocSPARSE status code enum name

--- a/library/src/rocsparse_error.cpp
+++ b/library/src/rocsparse_error.cpp
@@ -37,7 +37,7 @@ rocsparse_status _rocsparse_error::get_status() const
     return this->m_status;
 }
 
-extern "C" const char* rocsparse_error_message(rocsparse_error error)
+extern "C" const char* rocsparse_error_get_message(rocsparse_error error)
 try
 {
     ROCSPARSE_ROUTINE_TRACE;


### PR DESCRIPTION

Summary of proposed changes:
- Adjusting documentation
- Renaming "rocsparse_error_message" with "rocsparse_error_get_message"
