### PR TITLE
Fix spgeam extra test that was failing

### DIFF
--- a/clients/tests/test_spgeam_csr.yaml
+++ b/clients/tests/test_spgeam_csr.yaml
@@ -47,7 +47,7 @@ Tests:
   precision: *single_double_precisions_complex_real
 
 - name: spgeam_csr_extra
-  category: nightly
+  category: pre_checkin
   transA: [rocsparse_operation_none]
   transB: [rocsparse_operation_none]
   baseA: [rocsparse_index_base_zero, rocsparse_index_base_one]

--- a/library/src/extra/rocsparse_spgeam.cpp
+++ b/library/src/extra/rocsparse_spgeam.cpp
@@ -395,10 +395,7 @@ namespace rocsparse
                 {
                     // Temporary hack to handle the fact that we pass mat_C->nnz as an int64_t* but internally in order to match
                     // the legacy API we handle nnz_C using int32_t* when csr_row_ptr_C is int32_t*
-                    int32_t* int32_nnz_C;
-                    int32_nnz_C = reinterpret_cast<int32_t*>(&mat_C->nnz);
-
-                    mat_C->nnz = *int32_nnz_C;
+                    mat_C->nnz = *reinterpret_cast<const int32_t*>(&mat_C->nnz);
                 }
 
                 return rocsparse_status_success;

--- a/library/src/extra/rocsparse_spgeam.cpp
+++ b/library/src/extra/rocsparse_spgeam.cpp
@@ -391,6 +391,16 @@ namespace rocsparse
                     temp_buffer,
                     true));
 
+                if(mat_C != nullptr && mat_C->row_type == rocsparse_indextype_i32)
+                {
+                    // Temporary hack to handle the fact that we pass mat_C->nnz as an int64_t* but internally in order to match
+                    // the legacy API we handle nnz_C using int32_t* when csr_row_ptr_C is int32_t*
+                    int32_t* int32_nnz_C;
+                    int32_nnz_C = reinterpret_cast<int32_t*>(&mat_C->nnz);
+
+                    mat_C->nnz = *int32_nnz_C;
+                }
+
                 return rocsparse_status_success;
             }
             case rocsparse_format_bsr:


### PR DESCRIPTION
Summary of proposed changes:
- Fixes SpGEAM failing extra test
- This test was checking the case where a user was using `int32_t` for the sparse CSR row pointer array but where `int64_t` would be required because the nonzero count it above `INT32_MAX`.
- What should happen is that `nnz_C=-1` is returned to the user indicating to them that the compute phase will not work with their current  `int32_t` row pointer array for C
- Because of how the generic API and legacy API interact, we were not correctly handling this which is now fixed by this PR.
- Also moved these extra tests to pre_checkin in order to run these tests earlier and more frequently. 
