### PR TITLE
Fix clang formatting broken in previous commit

### DIFF
--- a/library/src/auxiliary/handle.cpp
+++ b/library/src/auxiliary/handle.cpp
@@ -21,8 +21,8 @@
  *
  * ************************************************************************ */
 
-#include "rocsparse_handle.hpp"
 #include "rocsparse_control.hpp"
+#include "rocsparse_handle.hpp"
 #include "rocsparse_logging.hpp"
 #include "rocsparse_utility.hpp"
 
@@ -916,7 +916,6 @@ bool rocsparse::check_trm_shared(const rocsparse_mat_info info, rocsparse_trm_in
     return (shared > 0) ? true : false;
 }
 
-
 /********************************************************************************
  * \brief rocsparse_csrgemm_info is a structure holding the rocsparse csrgemm
  * info data gathered during csrgemm_buffer_size. It must be initialized using
@@ -1134,29 +1133,28 @@ std::string rocsparse::handle_get_xnack_mode(rocsparse_handle handle)
     return XnackMode<hipDeviceProp_t>{}(handle->properties);
 }
 
-
 // Convert the current C++ exception to rocsparse_status
 // This allows extern "C" functions to return this function in a catch(...) block
 // while converting all C++ exceptions to an equivalent rocsparse_status here
 rocsparse_status rocsparse::exception_to_rocsparse_status(std::exception_ptr e)
-  try
-    {
-      if(e)
-	std::rethrow_exception(e);
-      return rocsparse_status_success;
-    }
-  catch(const rocsparse_status& status)
-    {
-      return status;
-    }
-  catch(const std::bad_alloc&)
-    {
-      return rocsparse_status_memory_error;
-    }
-  catch(...)
-    {
-      return rocsparse_status_thrown_exception;
-    }
+try
+{
+    if(e)
+        std::rethrow_exception(e);
+    return rocsparse_status_success;
+}
+catch(const rocsparse_status& status)
+{
+    return status;
+}
+catch(const std::bad_alloc&)
+{
+    return rocsparse_status_memory_error;
+}
+catch(...)
+{
+    return rocsparse_status_thrown_exception;
+}
 
 /*******************************************************************************
  * \brief convert hipError_t to rocsparse_status

--- a/library/src/common/rocsparse_blas.cpp
+++ b/library/src/common/rocsparse_blas.cpp
@@ -20,27 +20,27 @@
  * THE SOFTWARE.
  *
  * ************************************************************************ */
+#include "rocsparse_blas_rocblas.hpp"
 #include "rocsparse_control.hpp"
 #include "rocsparse_handle.hpp"
-#include "rocsparse_blas_rocblas.hpp"
 #include "rocsparse_utility.hpp"
 
 template <>
 bool rocsparse::enum_utils::is_invalid(rocsparse::blas_impl value)
 {
-  switch(value)
+    switch(value)
     {
     case rocsparse::blas_impl_none:
     case rocsparse::blas_impl_default:
     case rocsparse::blas_impl_rocblas:
-      {
-	return false;
-      }
+    {
+        return false;
     }
-  return true;
+    }
+    return true;
 }
 
-template<>
+template <>
 const char* rocsparse::enum_utils::to_string(rocsparse::blas_impl value)
 {
 

--- a/library/src/common/rocsparse_determine_indextype.cpp
+++ b/library/src/common/rocsparse_determine_indextype.cpp
@@ -23,9 +23,9 @@
 #include "rocsparse_determine_indextype.hpp"
 #include "rocsparse_handle.hpp"
 
-rocsparse_indextype  rocsparse::determine_I_indextype(rocsparse_const_spmat_descr mat)
+rocsparse_indextype rocsparse::determine_I_indextype(rocsparse_const_spmat_descr mat)
 {
-  switch(mat->format)
+    switch(mat->format)
     {
     case rocsparse_format_coo:
     case rocsparse_format_coo_aos:
@@ -33,19 +33,19 @@ rocsparse_indextype  rocsparse::determine_I_indextype(rocsparse_const_spmat_desc
     case rocsparse_format_ell:
     case rocsparse_format_bell:
     case rocsparse_format_bsr:
-      {
-	return mat->row_type;
-      }
+    {
+        return mat->row_type;
+    }
     case rocsparse_format_csc:
-      {
-	return mat->col_type;
-      }
+    {
+        return mat->col_type;
+    }
     }
 }
 
-rocsparse_indextype  rocsparse::determine_J_indextype(rocsparse_const_spmat_descr mat)
+rocsparse_indextype rocsparse::determine_J_indextype(rocsparse_const_spmat_descr mat)
 {
-  switch(mat->format)
+    switch(mat->format)
     {
     case rocsparse_format_coo:
     case rocsparse_format_coo_aos:
@@ -53,12 +53,12 @@ rocsparse_indextype  rocsparse::determine_J_indextype(rocsparse_const_spmat_desc
     case rocsparse_format_ell:
     case rocsparse_format_bell:
     case rocsparse_format_bsr:
-      {
-	return mat->col_type;
-      }
+    {
+        return mat->col_type;
+    }
     case rocsparse_format_csc:
-      {
-	return mat->row_type;
-      }
+    {
+        return mat->row_type;
+    }
     }
 }

--- a/library/src/common/rocsparse_memstat.cpp
+++ b/library/src/common/rocsparse_memstat.cpp
@@ -243,7 +243,7 @@ private:
         }
     };
 
-    memstat(const memstat&)            = delete;
+    memstat(const memstat&) = delete;
     memstat& operator=(const memstat&) = delete;
 
     struct stat

--- a/library/src/common/rocsparse_memstat.cpp
+++ b/library/src/common/rocsparse_memstat.cpp
@@ -23,10 +23,11 @@
 
 #ifdef ROCSPARSE_WITH_MEMSTAT
 
-#include "rocsparse_control.hpp"
-#include "rocsparse_envariables.hpp"
 #include "rocsparse_memstat.hpp"
 #include "rocsparse-types.h"
+#include "rocsparse_control.hpp"
+#include "rocsparse_envariables.hpp"
+
 #include <chrono>
 #include <fstream>
 #include <iomanip>
@@ -242,7 +243,7 @@ private:
         }
     };
 
-    memstat(const memstat&) = delete;
+    memstat(const memstat&)            = delete;
     memstat& operator=(const memstat&) = delete;
 
     struct stat

--- a/library/src/common/rocsparse_message.cpp
+++ b/library/src/common/rocsparse_message.cpp
@@ -25,8 +25,8 @@
 
 #include "rocsparse_control.hpp"
 #include "rocsparse_debug.hpp"
-#include "rocsparse_envariables.hpp"
 #include "rocsparse_enum_utils.hpp"
+#include "rocsparse_envariables.hpp"
 #include <map>
 
 void rocsparse::message(const char* msg_, const char* function_, const char* file_, int line_)

--- a/library/src/include/rocsparse_control.hpp
+++ b/library/src/include/rocsparse_control.hpp
@@ -41,13 +41,12 @@
 #define ROCSPARSE_COV_EXCL_START (void)("LCOV_EXCL_START")
 #define ROCSPARSE_COV_EXCL_STOP (void)("LCOV_EXCL_STOP")
 
-
 namespace rocsparse
 {
-  rocsparse_status exception_to_rocsparse_status(std::exception_ptr e = std::current_exception());
+    rocsparse_status exception_to_rocsparse_status(std::exception_ptr e = std::current_exception());
     /*******************************************************************************
- * \brief convert hipError_t to rocsparse_status
- ******************************************************************************/
+    * \brief convert hipError_t to rocsparse_status
+    ******************************************************************************/
     rocsparse_status get_rocsparse_status_for_hip_status(hipError_t status);
 }
 
@@ -241,7 +240,6 @@ namespace rocsparse
             throw TMP_STATUS_FOR_CHECK;                                         \
         }                                                                       \
     } while(false)
-
 
 //
 //

--- a/library/src/include/rocsparse_debug.hpp
+++ b/library/src/include/rocsparse_debug.hpp
@@ -24,8 +24,8 @@
 
 #pragma once
 
-#include "rocsparse_envariables.hpp"
 #include "rocsparse-types.h"
+#include "rocsparse_envariables.hpp"
 
 namespace rocsparse
 {


### PR DESCRIPTION
Summary of proposed changes:
- Formatting got broken in https://github.com/ROCm/rocSPARSE/pull/485
