### PR TITLE
relax the tolerance for nightly/spmm_csr.level3/*_mc2depi

### DIFF
--- a/clients/tests/test_spmm_csr.yaml
+++ b/clients/tests/test_spmm_csr.yaml
@@ -639,6 +639,7 @@ Tests:
   M: 1
   N: [40, 41, 42, 52]
   K: 1
+  tolm: 5.0
   alpha_beta: *alpha_beta_range_nightly
   transA: [rocsparse_operation_none]
   transB: [rocsparse_operation_none]


### PR DESCRIPTION
Two tests fail on some architecture due to rounding errors:

```
2 tests failed

nightly/spmm_csr.level3/i32_i32_f64_r_f64_r_f64_r_f64_r_1_42_1_n1_0_n0p5_0_NT_NT_1b_row_row_csrrow_split_csr_0_mc2depi
nightly/spmm_csr.level3/i64_i64_f64_r_f64_r_f64_r_f64_r_1_42_1_n1_0_n0p5_0_NT_NT_1b_row_row_csrrow_split_csr_0_mc2depi
[ RUN      ] nightly/spmm_csr.level3/i64_i64_f64_r_f64_r_f64_r_f64_r_1_42_1_n1_0_n0p5_0_NT_NT_1b_row_row_csrrow_split_csr_0_mc2depi
Opening file '/root/rocSPARSE/matrices/mc2depi.csr' ... 
Import done.
ASSERT_NEAR(0.000181983575552, 0.000181983575476) failed: 7.5384143372e-14 exceeds permissive range [1.81983575552e-14,7.27934302207e-14 ]
Test failed with tol = 1e-10. Relaxing the tolerance to at least 4.14235972359e-10 would make the test pass.
/longer_pathname_so_that_rpms_can_support_packaging_the_debug_info_for_all_os_profiles/src/rocSPARSE/clients/common/rocsparse_check.cpp:279: Failure
Value of: passed
  Actual: false
Expected: true
```

This PR relaxes the tolerance multiplier for these two tests.