### PR TITLE
Removing use of itilu0 deprecated enum

### DIFF
--- a/library/src/precond/itilu0/rocsparse_csritilu0_buffer_size.cpp
+++ b/library/src/precond/itilu0/rocsparse_csritilu0_buffer_size.cpp
@@ -41,7 +41,6 @@ const char* rocsparse::enum_utils::to_string(rocsparse_itilu0_alg value)
         CASE(rocsparse_itilu0_alg_async_inplace);
         CASE(rocsparse_itilu0_alg_async_split);
         CASE(rocsparse_itilu0_alg_sync_split);
-        CASE(rocsparse_itilu0_alg_sync_split_fusion);
 #undef CASE
     }
     // LCOV_EXCL_START
@@ -58,7 +57,6 @@ bool rocsparse::enum_utils::is_invalid(rocsparse_itilu0_alg value)
     case rocsparse_itilu0_alg_async_inplace:
     case rocsparse_itilu0_alg_async_split:
     case rocsparse_itilu0_alg_sync_split:
-    case rocsparse_itilu0_alg_sync_split_fusion:
     {
         return false;
     }
@@ -94,14 +92,6 @@ namespace rocsparse
             RETURN_IF_ROCSPARSE_ERROR(
                 (rocsparse::csritilu0_driver_t<
                     rocsparse_itilu0_alg_sync_split>::buffer_size<I, J>::run(parameters...)));
-            return rocsparse_status_success;
-        }
-
-        case rocsparse_itilu0_alg_sync_split_fusion:
-        {
-            RETURN_IF_ROCSPARSE_ERROR(
-                (rocsparse::csritilu0_driver_t<rocsparse_itilu0_alg_sync_split_fusion>::
-                     buffer_size<I, J>::run(parameters...)));
             return rocsparse_status_success;
         }
         }

--- a/library/src/precond/itilu0/rocsparse_csritilu0_compute.cpp
+++ b/library/src/precond/itilu0/rocsparse_csritilu0_compute.cpp
@@ -55,13 +55,6 @@ namespace rocsparse
                     rocsparse_itilu0_alg_sync_split>::compute<T, I, J>::run(parameters...)));
             return rocsparse_status_success;
         }
-        case rocsparse_itilu0_alg_sync_split_fusion:
-        {
-            RETURN_IF_ROCSPARSE_ERROR(
-                (rocsparse::csritilu0_driver_t<
-                    rocsparse_itilu0_alg_sync_split_fusion>::compute<T, I, J>::run(parameters...)));
-            return rocsparse_status_success;
-        }
         }
 
         // LCOV_EXCL_START

--- a/library/src/precond/itilu0/rocsparse_csritilu0_compute_ex.cpp
+++ b/library/src/precond/itilu0/rocsparse_csritilu0_compute_ex.cpp
@@ -55,13 +55,6 @@ namespace rocsparse
                     rocsparse_itilu0_alg_sync_split>::compute<T, I, J>::run(parameters...)));
             return rocsparse_status_success;
         }
-        case rocsparse_itilu0_alg_sync_split_fusion:
-        {
-            RETURN_IF_ROCSPARSE_ERROR(
-                (rocsparse::csritilu0_driver_t<
-                    rocsparse_itilu0_alg_sync_split_fusion>::compute<T, I, J>::run(parameters...)));
-            return rocsparse_status_success;
-        }
         }
 
         // LCOV_EXCL_START

--- a/library/src/precond/itilu0/rocsparse_csritilu0_history.cpp
+++ b/library/src/precond/itilu0/rocsparse_csritilu0_history.cpp
@@ -56,13 +56,6 @@ namespace rocsparse
                      history<rocsparse::floating_data_t<T>, J>::run(parameters...)));
             return rocsparse_status_success;
         }
-        case rocsparse_itilu0_alg_sync_split_fusion:
-        {
-            RETURN_IF_ROCSPARSE_ERROR(
-                (rocsparse::csritilu0_driver_t<rocsparse_itilu0_alg_sync_split_fusion>::
-                     history<rocsparse::floating_data_t<T>, J>::run(parameters...)));
-            return rocsparse_status_success;
-        }
         }
 
         // LCOV_EXCL_START

--- a/library/src/precond/itilu0/rocsparse_csritilu0_preprocess.cpp
+++ b/library/src/precond/itilu0/rocsparse_csritilu0_preprocess.cpp
@@ -56,13 +56,6 @@ namespace rocsparse
                     rocsparse_itilu0_alg_sync_split>::preprocess<I, J>::run(parameters...)));
             return rocsparse_status_success;
         }
-        case rocsparse_itilu0_alg_sync_split_fusion:
-        {
-            RETURN_IF_ROCSPARSE_ERROR(
-                (rocsparse::csritilu0_driver_t<
-                    rocsparse_itilu0_alg_sync_split_fusion>::preprocess<I, J>::run(parameters...)));
-            return rocsparse_status_success;
-        }
         }
 
         // LCOV_EXCL_START

--- a/library/src/precond/itilu0/rocsparse_csritilu0x_buffer_size.cpp
+++ b/library/src/precond/itilu0/rocsparse_csritilu0x_buffer_size.cpp
@@ -53,13 +53,6 @@ namespace rocsparse
                     rocsparse_itilu0_alg_sync_split>::buffer_size<I, J>::run(parameters...)));
             return rocsparse_status_success;
         }
-        case rocsparse_itilu0_alg_sync_split_fusion:
-        {
-            RETURN_IF_ROCSPARSE_ERROR(
-                (rocsparse::csritilu0x_driver_t<rocsparse_itilu0_alg_sync_split_fusion>::
-                     buffer_size<I, J>::run(parameters...)));
-            return rocsparse_status_success;
-        }
         }
         // LCOV_EXCL_START
         RETURN_IF_ROCSPARSE_ERROR(rocsparse_status_invalid_value);

--- a/library/src/precond/itilu0/rocsparse_csritilu0x_compute.cpp
+++ b/library/src/precond/itilu0/rocsparse_csritilu0x_compute.cpp
@@ -53,13 +53,6 @@ namespace rocsparse
                     rocsparse_itilu0_alg_sync_split>::compute<T, I, J>::run(parameters...)));
             return rocsparse_status_success;
         }
-        case rocsparse_itilu0_alg_sync_split_fusion:
-        {
-            RETURN_IF_ROCSPARSE_ERROR(
-                (rocsparse::csritilu0x_driver_t<
-                    rocsparse_itilu0_alg_sync_split_fusion>::compute<T, I, J>::run(parameters...)));
-            return rocsparse_status_success;
-        }
         }
         // LCOV_EXCL_START
         RETURN_IF_ROCSPARSE_ERROR(rocsparse_status_invalid_value);

--- a/library/src/precond/itilu0/rocsparse_csritilu0x_history.cpp
+++ b/library/src/precond/itilu0/rocsparse_csritilu0x_history.cpp
@@ -40,13 +40,6 @@ namespace rocsparse
             return rocsparse_status_success;
         }
 
-        case rocsparse_itilu0_alg_sync_split_fusion:
-        {
-            RETURN_IF_ROCSPARSE_ERROR(
-                (rocsparse::csritilu0x_driver_t<
-                    rocsparse_itilu0_alg_sync_split_fusion>::history<T, J>::run(parameters...)));
-            return rocsparse_status_success;
-        }
         case rocsparse_itilu0_alg_sync_split:
         {
             RETURN_IF_ROCSPARSE_ERROR((

--- a/library/src/precond/itilu0/rocsparse_csritilu0x_preprocess.cpp
+++ b/library/src/precond/itilu0/rocsparse_csritilu0x_preprocess.cpp
@@ -53,13 +53,6 @@ namespace rocsparse
                     rocsparse_itilu0_alg_sync_split>::preprocess<I, J>::run(parameters...)));
             return rocsparse_status_success;
         }
-        case rocsparse_itilu0_alg_sync_split_fusion:
-        {
-            RETURN_IF_ROCSPARSE_ERROR(
-                (rocsparse::csritilu0x_driver_t<
-                    rocsparse_itilu0_alg_sync_split_fusion>::preprocess<I, J>::run(parameters...)));
-            return rocsparse_status_success;
-        }
         }
         // LCOV_EXCL_START
         RETURN_IF_ROCSPARSE_ERROR(rocsparse_status_invalid_value);


### PR DESCRIPTION
Removes use of rocsparse_itilu0_alg_sync_split_fusion, which is deprecated.