### PR TITLE
Handle ROCTX using find_path and find_library instead of Findroctx.cmake module

### DIFF
--- a/clients/benchmarks/CMakeLists.txt
+++ b/clients/benchmarks/CMakeLists.txt
@@ -232,8 +232,15 @@ endif()
 
 if (NOT WIN32)
   if (BUILD_WITH_ROCTX)
-    target_link_libraries(rocsparse-bench PRIVATE -lroctx64)
-    target_compile_definitions( rocsparse-bench PRIVATE ROCSPARSE_CLIENTS_WITH_ROCTX )
+
+    if(ROCTRACER_INCLUDE_DIR AND ROCTX_LIBRARY)
+      # Add the include directory
+      target_include_directories(rocsparse-bench PRIVATE ${ROCTRACER_INCLUDE_DIR})
+
+      # Link the rocTx lib
+      target_link_libraries(rocsparse-bench PRIVATE ${ROCTX_LIBRARY})
+      target_compile_definitions( rocsparse-bench PRIVATE ROCSPARSE_CLIENTS_WITH_ROCTX )
+    endif()
   endif()
 endif()
 

--- a/clients/tests/CMakeLists.txt
+++ b/clients/tests/CMakeLists.txt
@@ -416,8 +416,14 @@ endif()
 
 if (NOT WIN32)
   if (BUILD_WITH_ROCTX)
-    target_link_libraries(rocsparse-test PRIVATE -lroctx64)
-    target_compile_definitions( rocsparse-test PRIVATE ROCSPARSE_CLIENTS_WITH_ROCTX )
+    if(ROCTRACER_INCLUDE_DIR AND ROCTX_LIBRARY)
+      # Add the include directory
+      target_include_directories(rocsparse-test PRIVATE ${ROCTRACER_INCLUDE_DIR})
+
+      # Link the rocTx lib
+      target_link_libraries(rocsparse-test PRIVATE ${ROCTX_LIBRARY})
+      target_compile_definitions( rocsparse-test PRIVATE ROCSPARSE_CLIENTS_WITH_ROCTX )
+    endif()
   endif()
 endif()
 

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -96,8 +96,56 @@ endif()
 
 if (NOT WIN32)
   if (BUILD_SHARED_LIBS AND BUILD_WITH_ROCTX)
-    target_link_libraries(rocsparse PRIVATE -lroctx64)
-    target_compile_definitions( rocsparse PRIVATE ROCSPARSE_BUILT_WITH_ROCTX )
+
+    message("ROCTX_PATH before : ${ROCTX_PATH}")
+
+    set(ROCTX_PATH "" CACHE STRING "Path to the roctx library (directory containing libroctx64.so)")
+
+
+    message("ROCTX_PATH after : ${ROCTX_PATH}")
+
+
+    find_path(ROCTRACER_INCLUDE_DIR
+      NAMES roctracer/roctx.h
+      HINTS
+      ${ROCTX_PATH}
+      ${ROCTX_PATH}/include
+      /opt/rocm/include
+      ${ROCTX_PATH}/../include
+      DOC "Path to the roctracer include directory containing roctx.h")
+
+    find_library(ROCTX_LIBRARY
+      NAMES roctx64
+      HINTS
+      ${ROCTX_PATH} # User-provided path
+      ${ROCTX_PATH}/lib
+      ${ROCTX_PATH}/lib64
+      PATHS
+      /opt/rocm/lib # Default ROCm path
+    )
+
+    if(ROCTRACER_INCLUDE_DIR AND ROCTX_LIBRARY)
+      message(STATUS "Found roctracer include directory: ${ROCTRACER_INCLUDE_DIR}")
+      message(STATUS "Found roctx library: ${ROCTX_LIBRARY}")
+
+      # Add the include directory
+      target_include_directories(rocsparse PRIVATE ${ROCTRACER_INCLUDE_DIR})
+
+      # Link the rocTx lib
+      target_link_libraries(rocsparse PRIVATE ${ROCTX_LIBRARY})
+      target_compile_definitions( rocsparse PRIVATE ROCSPARSE_BUILT_WITH_ROCTX )
+      message(STATUS "ROCTX tracing support enabled for target rocsparse.")
+    else()
+      message(WARNING "ROCTX tracing will be disabled for target rocsparse.")
+
+      if(NOT ROCTRACER_INCLUDE_DIR)
+        message(WARNING "Header 'roctracer/roctx.h' not found.")
+      endif()
+
+      if(NOT ROCTX_LIBRARY)
+        message(WARNING "Library 'roctx64' not found. ROCTX_PATH: '${ROCTX_PATH}' Default PATH: '/opt/rocm/lib'.")
+      endif()
+    endif()
   endif()
 endif()
 

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -97,13 +97,7 @@ endif()
 if (NOT WIN32)
   if (BUILD_SHARED_LIBS AND BUILD_WITH_ROCTX)
 
-    message("ROCTX_PATH before : ${ROCTX_PATH}")
-
     set(ROCTX_PATH "" CACHE STRING "Path to the roctx library (directory containing libroctx64.so)")
-
-
-    message("ROCTX_PATH after : ${ROCTX_PATH}")
-
 
     find_path(ROCTRACER_INCLUDE_DIR
       NAMES roctracer/roctx.h


### PR DESCRIPTION
Summary of proposed changes:
- This better handles supporting rocTX in rocSPARSE given rocTRACER does not ship a `roctxConfig.cmake` file and so we cannot use `find_package(roctracer)` from rocSPARSE.
- Previously we tried using our own custom `Findroctx.cmake` module file included as part of rocSPARSE, but this was deemed not appropriate going forward. See https://github.com/ROCm/rocSPARSE/pull/484
- Instead I have gone back to doing something similar to how MIopen and rocBLAS handle incorporating rocTX by using `find_path` and `find_library` to search for the roctracer header files and roctx shared library.