### PR TITLE
Fixing missing behavior check in spgeam

### DIFF
--- a/clients/samples/example_spgeam_3.cpp
+++ b/clients/samples/example_spgeam_3.cpp
@@ -245,8 +245,14 @@ int main(int argc, char* argv[])
         &C, m, n, nnz_C, dcsr_row_ptr_C, dcsr_col_ind_C, dcsr_val_C, itype, jtype, base, ttype));
 
     // Symbolic compute phase
-    ROCSPARSE_CHECK(rocsparse_spgeam_buffer_size(
-        handle, descr, A, B, C, rocsparse_spgeam_stage_symbolic, &buffer_size_in_bytes, nullptr));
+    ROCSPARSE_CHECK(rocsparse_spgeam_buffer_size(handle,
+                                                 descr,
+                                                 A,
+                                                 B,
+                                                 C,
+                                                 rocsparse_spgeam_stage_symbolic_compute,
+                                                 &buffer_size_in_bytes,
+                                                 nullptr));
 
     HIP_CHECK(hipMalloc(&buffer, buffer_size_in_bytes));
     ROCSPARSE_CHECK(rocsparse_spgeam(handle,
@@ -256,15 +262,21 @@ int main(int argc, char* argv[])
                                      &beta,
                                      B,
                                      C,
-                                     rocsparse_spgeam_stage_symbolic,
+                                     rocsparse_spgeam_stage_symbolic_compute,
                                      buffer_size_in_bytes,
                                      buffer,
                                      nullptr));
     HIP_CHECK(hipFree(buffer));
 
     // Numerical compute phase
-    ROCSPARSE_CHECK(rocsparse_spgeam_buffer_size(
-        handle, descr, A, B, C, rocsparse_spgeam_stage_numeric, &buffer_size_in_bytes, nullptr));
+    ROCSPARSE_CHECK(rocsparse_spgeam_buffer_size(handle,
+                                                 descr,
+                                                 A,
+                                                 B,
+                                                 C,
+                                                 rocsparse_spgeam_stage_numeric_compute,
+                                                 &buffer_size_in_bytes,
+                                                 nullptr));
 
     HIP_CHECK(hipMalloc(&buffer, buffer_size_in_bytes));
     ROCSPARSE_CHECK(rocsparse_spgeam(handle,
@@ -274,7 +286,7 @@ int main(int argc, char* argv[])
                                      &beta,
                                      B,
                                      C,
-                                     rocsparse_spgeam_stage_numeric,
+                                     rocsparse_spgeam_stage_numeric_compute,
                                      buffer_size_in_bytes,
                                      buffer,
                                      nullptr));
@@ -324,8 +336,14 @@ int main(int argc, char* argv[])
     ROCSPARSE_CHECK(rocsparse_csr_set_pointers(A, dcsr_row_ptr_A, dcsr_col_ind_A, dcsr_val_A));
     ROCSPARSE_CHECK(rocsparse_csr_set_pointers(B, dcsr_row_ptr_B, dcsr_col_ind_B, dcsr_val_B));
 
-    ROCSPARSE_CHECK(rocsparse_spgeam_buffer_size(
-        handle, descr, A, B, C, rocsparse_spgeam_stage_numeric, &buffer_size_in_bytes, nullptr));
+    ROCSPARSE_CHECK(rocsparse_spgeam_buffer_size(handle,
+                                                 descr,
+                                                 A,
+                                                 B,
+                                                 C,
+                                                 rocsparse_spgeam_stage_numeric_compute,
+                                                 &buffer_size_in_bytes,
+                                                 nullptr));
 
     // Numerical compute phase
     HIP_CHECK(hipMalloc(&buffer, buffer_size_in_bytes));
@@ -336,7 +354,7 @@ int main(int argc, char* argv[])
                                      &beta,
                                      B,
                                      C,
-                                     rocsparse_spgeam_stage_numeric,
+                                     rocsparse_spgeam_stage_numeric_compute,
                                      buffer_size_in_bytes,
                                      buffer,
                                      nullptr));

--- a/clients/testings/testing.hpp
+++ b/clients/testings/testing.hpp
@@ -138,3 +138,52 @@ inline bool is_hmm_enabled()
 
     return hmm_enabled;
 }
+
+namespace rocsparse_clients
+{
+    struct archnames
+    {
+        static constexpr const char* const gfx90a  = "gfx90a";
+        static constexpr const char* const gfx942  = "gfx942";
+        static constexpr const char* const gfx803  = "gfx803";
+        static constexpr const char* const gfx900  = "gfx900";
+        static constexpr const char* const gfx906  = "gfx906";
+        static constexpr const char* const gfx908  = "gfx908";
+        static constexpr const char* const gfx950  = "gfx950";
+        static constexpr const char* const gfx1030 = "gfx1030";
+        static constexpr const char* const gfx1100 = "gfx1100";
+        static constexpr const char* const gfx1101 = "gfx1101";
+        static constexpr const char* const gfx1102 = "gfx1102";
+        static constexpr const char* const gfx1151 = "gfx1151";
+        static constexpr const char* const gfx1200 = "gfx1200";
+        static constexpr const char* const gfx1201 = "gfx1201";
+    };
+
+    inline bool archname_from(const char* archname, const char* name)
+    {
+        return (0 == strncmp(name, archname, strlen(name)));
+    }
+
+    template <typename... P>
+    inline bool archname_from(const char* archname, const char* name, P... p)
+    {
+        if(0 == strncmp(name, archname, strlen(name)))
+        {
+            return true;
+        }
+        return rocsparse_clients::archname_from(archname, std::forward<P>(p)...);
+    }
+
+    template <typename... P>
+    inline bool current_arch_from(P... p)
+    {
+        int             dev;
+        hipDeviceProp_t prop;
+        std::ignore = hipGetDevice(&dev);
+        std::ignore = hipGetDeviceProperties(&prop, dev);
+        return rocsparse_clients::archname_from(prop.gcnArchName, std::forward<P>(p)...);
+    }
+}
+
+#define ROCSPARSE_DEBUG_VERBOSE_ON rocsparse_enable_debug_verbose()
+#define ROCSPARSE_DEBUG_VERBOSE_OFF rocsparse_disable_debug_verbose()

--- a/clients/testings/testing_spgeam_csr.cpp
+++ b/clients/testings/testing_spgeam_csr.cpp
@@ -75,14 +75,14 @@ void testing_spgeam_csr_bad_arg(const Arguments& arg)
     size_t buffer_size = 0;
     void*  temp_buffer = nullptr;
 
-    int       nargs_to_exclude_buffer_size   = 3;
-    const int args_to_exclude_buffer_size[3] = {4, 6, 7};
+    int32_t       nargs_to_exclude_buffer_size   = 3;
+    const int32_t args_to_exclude_buffer_size[3] = {4, 6, 7};
 
-    int       nargs_to_exclude_analysis   = 6;
-    const int args_to_exclude_analysis[6] = {2, 4, 6, 8, 9, 10};
+    int32_t       nargs_to_exclude_analysis   = 6;
+    const int32_t args_to_exclude_analysis[6] = {2, 4, 6, 8, 9, 10};
 
-    int       nargs_to_exclude_compute   = 5;
-    const int args_to_exclude_compute[5] = {2, 4, 8, 9, 10};
+    int32_t       nargs_to_exclude_compute   = 5;
+    const int32_t args_to_exclude_compute[5] = {2, 4, 8, 9, 10};
 
     rocsparse_spgeam_stage stage = rocsparse_spgeam_stage_analysis;
     rocsparse_error*       p_error{};
@@ -314,7 +314,7 @@ void testing_spgeam_csr(const Arguments& arg)
 
         // Compute C on host multiple times.
         CHECK_ROCSPARSE_ERROR(rocsparse_set_pointer_mode(handle, rocsparse_pointer_mode_host));
-        for(int i = 0; i < 2; i++)
+        for(int32_t i = 0; i < 2; i++)
         {
             CHECK_ROCSPARSE_ERROR(rocsparse_spgeam(handle,
                                                    descr,
@@ -337,7 +337,7 @@ void testing_spgeam_csr(const Arguments& arg)
 
         // Compute C on device multiple times.
         CHECK_ROCSPARSE_ERROR(rocsparse_set_pointer_mode(handle, rocsparse_pointer_mode_device));
-        for(int i = 0; i < 2; i++)
+        for(int32_t i = 0; i < 2; i++)
         {
             CHECK_ROCSPARSE_ERROR(rocsparse_spgeam(handle,
                                                    descr,
@@ -361,13 +361,13 @@ void testing_spgeam_csr(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
-        int number_hot_calls  = arg.iters;
+        int32_t number_cold_calls = 2;
+        int32_t number_hot_calls  = arg.iters;
 
         CHECK_ROCSPARSE_ERROR(rocsparse_set_pointer_mode(handle, rocsparse_pointer_mode_host));
 
         // Warm up
-        for(int iter = 0; iter < number_cold_calls; ++iter)
+        for(int32_t iter = 0; iter < number_cold_calls; ++iter)
         {
             CHECK_ROCSPARSE_ERROR(rocsparse_spgeam(handle,
                                                    descr,
@@ -385,7 +385,7 @@ void testing_spgeam_csr(const Arguments& arg)
         double gpu_solve_time_used = get_time_us();
 
         // Performance run
-        for(int iter = 0; iter < number_hot_calls; ++iter)
+        for(int32_t iter = 0; iter < number_hot_calls; ++iter)
         {
             CHECK_ROCSPARSE_ERROR(rocsparse_spgeam(handle,
                                                    descr,
@@ -457,24 +457,26 @@ INSTANTIATE(int64_t, int64_t, float);
 INSTANTIATE(int64_t, int64_t, double);
 INSTANTIATE(int64_t, int64_t, rocsparse_float_complex);
 INSTANTIATE(int64_t, int64_t, rocsparse_double_complex);
-void testing_spgeam_csr_extra(const Arguments& arg)
+
+//
+// This test expects an overflow from the calculation of the number of non-zeros
+// when int32_t is used as the index type for the ptr array of the csr format.
+//
+static void testing_spgeam_csr_extra_expected_overflow(const Arguments& arg)
 {
-    int m     = 50000;
-    int n     = 50000;
-    int nnz_A = (m / 2) * n;
-    int nnz_B = (m / 2) * n;
-
-    float h_alpha = 1.0f;
-    float h_beta  = 1.0f;
-
-    rocsparse_index_base base_A  = arg.baseA;
-    rocsparse_index_base base_B  = arg.baseB;
-    rocsparse_index_base base_C  = arg.baseC;
-    rocsparse_operation  trans_A = arg.transA;
-    rocsparse_operation  trans_B = arg.transB;
-    rocsparse_spgeam_alg alg     = arg.spgeam_alg;
-
-    rocsparse_datatype ttype = get_datatype<float>();
+    const int32_t              m       = 50000;
+    const int32_t              n       = 50000;
+    const int32_t              nnz_A   = (m / 2) * n;
+    const int32_t              nnz_B   = (m / 2) * n;
+    const float                h_alpha = 1.0f;
+    const float                h_beta  = 1.0f;
+    const rocsparse_index_base base_A  = arg.baseA;
+    const rocsparse_index_base base_B  = arg.baseB;
+    const rocsparse_index_base base_C  = arg.baseC;
+    const rocsparse_operation  trans_A = arg.transA;
+    const rocsparse_operation  trans_B = arg.transB;
+    const rocsparse_spgeam_alg alg     = arg.spgeam_alg;
+    const rocsparse_datatype   ttype   = get_datatype<float>();
 
     // Create rocsparse handle
     rocsparse_local_handle handle;
@@ -483,11 +485,11 @@ void testing_spgeam_csr_extra(const Arguments& arg)
     hipStream_t stream = handle.get_stream();
 
     // Declare host matrices.
-    host_csr_matrix<float, int, int> hA(m, n, nnz_A, base_A);
-    host_csr_matrix<float, int, int> hB(m, n, nnz_B, base_B);
+    host_csr_matrix<float> hA(m, n, nnz_A, base_A);
+    host_csr_matrix<float> hB(m, n, nnz_B, base_B);
 
     hA.ptr[0] = base_A;
-    for(int i = 0; i < m; i++)
+    for(int32_t i = 0; i < m; i++)
     {
         if(i < (m / 2))
         {
@@ -499,12 +501,12 @@ void testing_spgeam_csr_extra(const Arguments& arg)
         }
     }
 
-    for(int i = 0; i < m; i++)
+    for(int32_t i = 0; i < m; i++)
     {
-        int start = hA.ptr[i] - base_A;
-        int end   = hA.ptr[i + 1] - base_A;
+        int32_t start = hA.ptr[i] - base_A;
+        int32_t end   = hA.ptr[i + 1] - base_A;
 
-        for(int j = start; j < end; j++)
+        for(int32_t j = start; j < end; j++)
         {
             hA.ind[j] = j - start + base_A;
             hA.val[j] = 1.0f;
@@ -512,7 +514,7 @@ void testing_spgeam_csr_extra(const Arguments& arg)
     }
 
     hB.ptr[0] = base_B;
-    for(int i = 0; i < m; i++)
+    for(int32_t i = 0; i < m; i++)
     {
         if(i < (m / 2))
         {
@@ -524,12 +526,12 @@ void testing_spgeam_csr_extra(const Arguments& arg)
         }
     }
 
-    for(int i = 0; i < m; i++)
+    for(int32_t i = 0; i < m; i++)
     {
-        int start = hB.ptr[i] - base_B;
-        int end   = hB.ptr[i + 1] - base_B;
+        int32_t start = hB.ptr[i] - base_B;
+        int32_t end   = hB.ptr[i + 1] - base_B;
 
-        for(int j = start; j < end; j++)
+        for(int32_t j = start; j < end; j++)
         {
             hB.ind[j] = j - start + base_B;
             hB.val[j] = 1.0f;
@@ -537,11 +539,11 @@ void testing_spgeam_csr_extra(const Arguments& arg)
     }
 
     // Declare device matrices.
-    device_csr_matrix<float, int, int> dA(hA);
-    device_csr_matrix<float, int, int> dB(hB);
+    device_csr_matrix<float> dA(hA);
+    device_csr_matrix<float> dB(hB);
 
     // Allocate and set up C
-    device_csr_matrix<float, int, int> dC(m, n, 0, base_C);
+    device_csr_matrix<float> dC(m, n, 0, base_C);
 
     // Declare local spmat.
     rocsparse_local_spmat A(dA), B(dB), C(dC);
@@ -591,4 +593,153 @@ void testing_spgeam_csr_extra(const Arguments& arg)
     EXPECT_ROCSPARSE_STATUS((nnz_C == -1) ? rocsparse_status_success
                                           : rocsparse_status_internal_error,
                             rocsparse_status_success);
+}
+
+//
+// This test messes up stages and checks that invalid status is returned.
+//
+static void testing_spgeam_csr_extra_wrong_stages(const Arguments& arg)
+{
+    const int32_t              m       = 2;
+    const int32_t              n       = 2;
+    const int32_t              nnz_A   = 2;
+    const int32_t              nnz_B   = 2;
+    const int32_t              nnz_C   = 2;
+    const float                h_alpha = 1.0f;
+    const float                h_beta  = 1.0f;
+    const rocsparse_index_base base_A  = rocsparse_index_base_zero;
+    const rocsparse_index_base base_B  = rocsparse_index_base_zero;
+    const rocsparse_index_base base_C  = rocsparse_index_base_zero;
+    const rocsparse_operation  trans_A = rocsparse_operation_none;
+    const rocsparse_operation  trans_B = rocsparse_operation_none;
+    const rocsparse_spgeam_alg alg     = rocsparse_spgeam_alg_default;
+    const rocsparse_datatype   ttype   = rocsparse_datatype_f32_r;
+    // Create rocsparse handle
+    rocsparse_local_handle handle;
+    // Declare host matrices.
+    host_csr_matrix<float> hA(m, n, nnz_A, base_A);
+    host_csr_matrix<float> hB(m, n, nnz_B, base_B);
+    host_csr_matrix<float> hC(m, n, nnz_C, base_C);
+    hA.ptr[0] = 0;
+    hA.ptr[1] = 1;
+    hA.ptr[2] = 2;
+    hA.ind[0] = 0;
+    hA.ind[1] = 1;
+    hA.val[0] = 1;
+    hA.val[1] = 1;
+
+    hB.ptr[0] = 0;
+    hB.ptr[1] = 1;
+    hB.ptr[2] = 2;
+    hB.ind[0] = 0;
+    hB.ind[1] = 1;
+    hB.val[0] = 1;
+    hB.val[1] = 1;
+
+    hC.ptr[0] = 0;
+    hC.ptr[1] = 1;
+    hC.ptr[2] = 2;
+    hC.ind[0] = 0;
+    hC.ind[1] = 1;
+    hC.val[0] = 2;
+    hC.val[1] = 2;
+
+    device_csr_matrix<float> dA(hA), dB(hB), dC(hC);
+    rocsparse_local_spmat    A(dA), B(dB), C(dC);
+
+    rocsparse_spgeam_descr descr;
+    CHECK_ROCSPARSE_ERROR(rocsparse_create_spgeam_descr(&descr));
+    CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(
+        handle, descr, rocsparse_spgeam_input_alg, &alg, sizeof(alg), nullptr));
+
+    CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(
+        handle, descr, rocsparse_spgeam_input_operation_A, &trans_A, sizeof(trans_A), nullptr));
+
+    CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(
+        handle, descr, rocsparse_spgeam_input_operation_B, &trans_B, sizeof(trans_B), nullptr));
+
+    CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(
+        handle, descr, rocsparse_spgeam_input_scalar_datatype, &ttype, sizeof(ttype), nullptr));
+
+    CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(
+        handle, descr, rocsparse_spgeam_input_compute_datatype, &ttype, sizeof(ttype), nullptr));
+
+    // Calculate NNZ phase
+    const size_t              buffer_size_in_bytes = 64;
+    device_dense_vector<char> buffer(buffer_size_in_bytes);
+
+#define PARAMS(stage) \
+    handle, descr, &h_alpha, A, &h_beta, B, C, stage, buffer_size_in_bytes, buffer, nullptr
+
+    //
+    // Expect an invalid status when calling compute before analysis
+    //
+    {
+        ROCSPARSE_DEBUG_VERBOSE_OFF;
+        EXPECT_ROCSPARSE_STATUS(rocsparse_spgeam(PARAMS(rocsparse_spgeam_stage_compute)),
+                                rocsparse_status_invalid_value);
+        ROCSPARSE_DEBUG_VERBOSE_ON;
+    }
+
+    //
+    // Call analysis
+    //
+    CHECK_ROCSPARSE_ERROR(rocsparse_spgeam(PARAMS(rocsparse_spgeam_stage_analysis)));
+
+    //
+    // Expect an invalid status when calling analysis twice
+    //
+    {
+        ROCSPARSE_DEBUG_VERBOSE_OFF;
+        EXPECT_ROCSPARSE_STATUS(rocsparse_spgeam(PARAMS(rocsparse_spgeam_stage_analysis)),
+                                rocsparse_status_invalid_value);
+        ROCSPARSE_DEBUG_VERBOSE_ON;
+    }
+
+    //
+    // Call compute.
+    //
+    CHECK_ROCSPARSE_ERROR(rocsparse_spgeam(PARAMS(rocsparse_spgeam_stage_compute)));
+
+    //
+    // Call compute twice.
+    //
+    CHECK_ROCSPARSE_ERROR(rocsparse_spgeam(PARAMS(rocsparse_spgeam_stage_compute)));
+
+    {
+        ROCSPARSE_DEBUG_VERBOSE_OFF;
+
+        //
+        // Expect an invalid status when calling analysis after compute
+        //
+        EXPECT_ROCSPARSE_STATUS(rocsparse_spgeam(PARAMS(rocsparse_spgeam_stage_analysis)),
+                                rocsparse_status_invalid_value);
+
+        //
+        // Expect an invalid status when calling symbolic_compute after compute
+        //
+        EXPECT_ROCSPARSE_STATUS(rocsparse_spgeam(PARAMS(rocsparse_spgeam_stage_symbolic_compute)),
+                                rocsparse_status_invalid_value);
+
+        //
+        // Expect an invalid status when calling numeric_compute after compute
+        //
+        EXPECT_ROCSPARSE_STATUS(rocsparse_spgeam(PARAMS(rocsparse_spgeam_stage_numeric_compute)),
+                                rocsparse_status_invalid_value);
+
+        ROCSPARSE_DEBUG_VERBOSE_ON;
+    }
+
+    CHECK_ROCSPARSE_ERROR(rocsparse_destroy_spgeam_descr(descr));
+#undef PARAMS
+}
+
+void testing_spgeam_csr_extra(const Arguments& arg)
+{
+    if(rocsparse_clients::current_arch_from(rocsparse_clients::archnames::gfx90a))
+    {
+        testing_spgeam_csr_extra_expected_overflow(arg);
+    }
+
+    testing_spgeam_csr_extra_wrong_stages(arg);
 }

--- a/clients/testings/testing_spgeam_reuse_csr.cpp
+++ b/clients/testings/testing_spgeam_reuse_csr.cpp
@@ -75,14 +75,14 @@ void testing_spgeam_reuse_csr_bad_arg(const Arguments& arg)
     size_t buffer_size = 0;
     void*  temp_buffer = nullptr;
 
-    int       nargs_to_exclude_buffer_size   = 3;
-    const int args_to_exclude_buffer_size[3] = {4, 6, 7};
+    int32_t       nargs_to_exclude_buffer_size   = 3;
+    const int32_t args_to_exclude_buffer_size[3] = {4, 6, 7};
 
-    int       nargs_to_exclude_analysis   = 6;
-    const int args_to_exclude_analysis[6] = {2, 4, 6, 8, 9, 10};
+    int32_t       nargs_to_exclude_analysis   = 6;
+    const int32_t args_to_exclude_analysis[6] = {2, 4, 6, 8, 9, 10};
 
-    int       nargs_to_exclude   = 5;
-    const int args_to_exclude[5] = {2, 4, 8, 9, 10};
+    int32_t       nargs_to_exclude   = 5;
+    const int32_t args_to_exclude[5] = {2, 4, 8, 9, 10};
 
     rocsparse_spgeam_stage stage = rocsparse_spgeam_stage_analysis;
     rocsparse_error*       p_error{};
@@ -114,9 +114,9 @@ void testing_spgeam_reuse_csr_bad_arg(const Arguments& arg)
                             temp_buffer,
                             p_error);
 
-    stage = rocsparse_spgeam_stage_symbolic;
+    stage = rocsparse_spgeam_stage_symbolic_compute;
 
-    // Symbolic
+    // Symbolic_Compute
     select_bad_arg_analysis(rocsparse_spgeam_buffer_size,
                             nargs_to_exclude_buffer_size,
                             args_to_exclude_buffer_size,
@@ -144,7 +144,7 @@ void testing_spgeam_reuse_csr_bad_arg(const Arguments& arg)
                             temp_buffer,
                             p_error);
 
-    stage = rocsparse_spgeam_stage_numeric;
+    stage = rocsparse_spgeam_stage_numeric_compute;
 
     // Numeric
     select_bad_arg_analysis(rocsparse_spgeam_buffer_size,
@@ -297,23 +297,10 @@ void testing_spgeam_reuse_csr(const Arguments& arg)
                                                        mat_A,
                                                        mat_B,
                                                        mat_C,
-                                                       rocsparse_spgeam_stage_symbolic,
+                                                       rocsparse_spgeam_stage_symbolic_compute,
                                                        &buffer_size_in_bytes,
                                                        nullptr));
     CHECK_HIP_ERROR(rocsparse_hipMalloc(&buffer, buffer_size_in_bytes));
-    CHECK_ROCSPARSE_ERROR(rocsparse_set_pointer_mode(handle, rocsparse_pointer_mode_host));
-    CHECK_ROCSPARSE_ERROR(rocsparse_spgeam(handle,
-                                           descr,
-                                           h_alpha_ptr,
-                                           mat_A,
-                                           h_beta_ptr,
-                                           mat_B,
-                                           mat_C,
-                                           rocsparse_spgeam_stage_symbolic,
-                                           buffer_size_in_bytes,
-                                           buffer,
-                                           nullptr));
-    CHECK_ROCSPARSE_ERROR(rocsparse_set_pointer_mode(handle, rocsparse_pointer_mode_device));
     CHECK_ROCSPARSE_ERROR(rocsparse_spgeam(handle,
                                            descr,
                                            d_alpha_ptr,
@@ -321,7 +308,7 @@ void testing_spgeam_reuse_csr(const Arguments& arg)
                                            d_beta_ptr,
                                            mat_B,
                                            mat_C,
-                                           rocsparse_spgeam_stage_symbolic,
+                                           rocsparse_spgeam_stage_symbolic_compute,
                                            buffer_size_in_bytes,
                                            buffer,
                                            nullptr));
@@ -333,7 +320,7 @@ void testing_spgeam_reuse_csr(const Arguments& arg)
                                                        mat_A,
                                                        mat_B,
                                                        mat_C,
-                                                       rocsparse_spgeam_stage_numeric,
+                                                       rocsparse_spgeam_stage_numeric_compute,
                                                        &buffer_size_in_bytes,
                                                        nullptr));
     CHECK_HIP_ERROR(rocsparse_hipMalloc(&buffer, buffer_size_in_bytes));
@@ -379,7 +366,7 @@ void testing_spgeam_reuse_csr(const Arguments& arg)
 
         // Compute C on host multiple times.
         CHECK_ROCSPARSE_ERROR(rocsparse_set_pointer_mode(handle, rocsparse_pointer_mode_host));
-        for(int i = 0; i < 2; i++)
+        for(int32_t i = 0; i < 2; i++)
         {
             CHECK_ROCSPARSE_ERROR(rocsparse_spgeam(handle,
                                                    descr,
@@ -388,7 +375,7 @@ void testing_spgeam_reuse_csr(const Arguments& arg)
                                                    h_beta_ptr,
                                                    mat_B,
                                                    mat_C,
-                                                   rocsparse_spgeam_stage_numeric,
+                                                   rocsparse_spgeam_stage_numeric_compute,
                                                    buffer_size_in_bytes,
                                                    buffer,
                                                    nullptr));
@@ -403,7 +390,7 @@ void testing_spgeam_reuse_csr(const Arguments& arg)
 
         // Compute C on device multiple times.
         CHECK_ROCSPARSE_ERROR(rocsparse_set_pointer_mode(handle, rocsparse_pointer_mode_device));
-        for(int i = 0; i < 2; i++)
+        for(int32_t i = 0; i < 2; i++)
         {
             CHECK_ROCSPARSE_ERROR(rocsparse_spgeam(handle,
                                                    descr,
@@ -412,7 +399,7 @@ void testing_spgeam_reuse_csr(const Arguments& arg)
                                                    d_beta_ptr,
                                                    mat_B,
                                                    mat_C,
-                                                   rocsparse_spgeam_stage_numeric,
+                                                   rocsparse_spgeam_stage_numeric_compute,
                                                    buffer_size_in_bytes,
                                                    buffer,
                                                    nullptr));
@@ -428,13 +415,13 @@ void testing_spgeam_reuse_csr(const Arguments& arg)
 
     if(arg.timing)
     {
-        int number_cold_calls = 2;
-        int number_hot_calls  = arg.iters;
+        int32_t number_cold_calls = 2;
+        int32_t number_hot_calls  = arg.iters;
 
         CHECK_ROCSPARSE_ERROR(rocsparse_set_pointer_mode(handle, rocsparse_pointer_mode_host));
 
         // Warm up
-        for(int iter = 0; iter < number_cold_calls; ++iter)
+        for(int32_t iter = 0; iter < number_cold_calls; ++iter)
         {
             CHECK_ROCSPARSE_ERROR(rocsparse_spgeam(handle,
                                                    descr,
@@ -443,7 +430,7 @@ void testing_spgeam_reuse_csr(const Arguments& arg)
                                                    h_beta_ptr,
                                                    mat_B,
                                                    mat_C,
-                                                   rocsparse_spgeam_stage_numeric,
+                                                   rocsparse_spgeam_stage_numeric_compute,
                                                    buffer_size_in_bytes,
                                                    buffer,
                                                    nullptr));
@@ -452,7 +439,7 @@ void testing_spgeam_reuse_csr(const Arguments& arg)
         double gpu_solve_time_used = get_time_us();
 
         // Performance run
-        for(int iter = 0; iter < number_hot_calls; ++iter)
+        for(int32_t iter = 0; iter < number_hot_calls; ++iter)
         {
             CHECK_ROCSPARSE_ERROR(rocsparse_spgeam(handle,
                                                    descr,
@@ -461,7 +448,7 @@ void testing_spgeam_reuse_csr(const Arguments& arg)
                                                    h_beta_ptr,
                                                    mat_B,
                                                    mat_C,
-                                                   rocsparse_spgeam_stage_numeric,
+                                                   rocsparse_spgeam_stage_numeric_compute,
                                                    buffer_size_in_bytes,
                                                    buffer,
                                                    nullptr));
@@ -524,4 +511,170 @@ INSTANTIATE(int64_t, int64_t, float);
 INSTANTIATE(int64_t, int64_t, double);
 INSTANTIATE(int64_t, int64_t, rocsparse_float_complex);
 INSTANTIATE(int64_t, int64_t, rocsparse_double_complex);
-void testing_spgeam_reuse_csr_extra(const Arguments& arg) {}
+
+//
+// This test messes up stages and checks that invalid status is returned.
+//
+static void testing_spgeam_reuse_csr_extra_wrong_stages(const Arguments& arg)
+{
+    const int32_t              m       = 2;
+    const int32_t              n       = 2;
+    const int32_t              nnz_A   = 2;
+    const int32_t              nnz_B   = 2;
+    const int32_t              nnz_C   = 2;
+    const float                h_alpha = 1.0f;
+    const float                h_beta  = 1.0f;
+    const rocsparse_index_base base_A  = rocsparse_index_base_zero;
+    const rocsparse_index_base base_B  = rocsparse_index_base_zero;
+    const rocsparse_index_base base_C  = rocsparse_index_base_zero;
+    const rocsparse_operation  trans_A = rocsparse_operation_none;
+    const rocsparse_operation  trans_B = rocsparse_operation_none;
+    const rocsparse_spgeam_alg alg     = rocsparse_spgeam_alg_default;
+    const rocsparse_datatype   ttype   = rocsparse_datatype_f32_r;
+    // Create rocsparse handle
+    rocsparse_local_handle handle;
+    // Declare host matrices.
+    host_csr_matrix<float> hA(m, n, nnz_A, base_A);
+    host_csr_matrix<float> hB(m, n, nnz_B, base_B);
+    host_csr_matrix<float> hC(m, n, nnz_C, base_C);
+    hA.ptr[0] = 0;
+    hA.ptr[1] = 1;
+    hA.ptr[2] = 2;
+    hA.ind[0] = 0;
+    hA.ind[1] = 1;
+    hA.val[0] = 1;
+    hA.val[1] = 1;
+
+    hB.ptr[0] = 0;
+    hB.ptr[1] = 1;
+    hB.ptr[2] = 2;
+    hB.ind[0] = 0;
+    hB.ind[1] = 1;
+    hB.val[0] = 1;
+    hB.val[1] = 1;
+
+    hC.ptr[0] = 0;
+    hC.ptr[1] = 1;
+    hC.ptr[2] = 2;
+    hC.ind[0] = 0;
+    hC.ind[1] = 1;
+    hC.val[0] = 2;
+    hC.val[1] = 2;
+
+    device_csr_matrix<float> dA(hA), dB(hB), dC(hC);
+    rocsparse_local_spmat    A(dA), B(dB), C(dC);
+
+    rocsparse_spgeam_descr descr;
+    CHECK_ROCSPARSE_ERROR(rocsparse_create_spgeam_descr(&descr));
+    CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(
+        handle, descr, rocsparse_spgeam_input_alg, &alg, sizeof(alg), nullptr));
+
+    CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(
+        handle, descr, rocsparse_spgeam_input_operation_A, &trans_A, sizeof(trans_A), nullptr));
+
+    CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(
+        handle, descr, rocsparse_spgeam_input_operation_B, &trans_B, sizeof(trans_B), nullptr));
+
+    CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(
+        handle, descr, rocsparse_spgeam_input_scalar_datatype, &ttype, sizeof(ttype), nullptr));
+
+    CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(
+        handle, descr, rocsparse_spgeam_input_compute_datatype, &ttype, sizeof(ttype), nullptr));
+
+    // Calculate NNZ phase
+    const size_t              buffer_size_in_bytes = 64;
+    device_dense_vector<char> buffer(buffer_size_in_bytes);
+
+#define PARAMS(stage) \
+    handle, descr, &h_alpha, A, &h_beta, B, C, stage, buffer_size_in_bytes, buffer, nullptr
+
+    {
+        ROCSPARSE_DEBUG_VERBOSE_OFF;
+        //
+        // Expect an invalid status when calling symbolic_compute before analysis
+        //
+        EXPECT_ROCSPARSE_STATUS(rocsparse_spgeam(PARAMS(rocsparse_spgeam_stage_symbolic_compute)),
+                                rocsparse_status_invalid_value);
+
+        //
+        // Expect an invalid status when calling numeric_compute before analysis
+        //
+        EXPECT_ROCSPARSE_STATUS(rocsparse_spgeam(PARAMS(rocsparse_spgeam_stage_numeric_compute)),
+                                rocsparse_status_invalid_value);
+
+        ROCSPARSE_DEBUG_VERBOSE_ON;
+    }
+
+    //
+    // Call analysis
+    //
+    CHECK_ROCSPARSE_ERROR(rocsparse_spgeam(PARAMS(rocsparse_spgeam_stage_analysis)));
+
+    {
+        ROCSPARSE_DEBUG_VERBOSE_OFF;
+        //
+        // Expect an invalid status when calling analysis twice
+        //
+        EXPECT_ROCSPARSE_STATUS(rocsparse_spgeam(PARAMS(rocsparse_spgeam_stage_analysis)),
+                                rocsparse_status_invalid_value);
+
+        ROCSPARSE_DEBUG_VERBOSE_ON;
+    }
+
+    //
+    // Call symbolic_compute
+    //
+    CHECK_ROCSPARSE_ERROR(rocsparse_spgeam(PARAMS(rocsparse_spgeam_stage_symbolic_compute)));
+
+    {
+        ROCSPARSE_DEBUG_VERBOSE_OFF;
+        //
+        // Expect an invalid status when calling symbolic_compute twice
+        //
+        EXPECT_ROCSPARSE_STATUS(rocsparse_spgeam(PARAMS(rocsparse_spgeam_stage_symbolic_compute)),
+                                rocsparse_status_invalid_value);
+
+        //
+        // Expect an invalid status when calling compute after symbolic_compute
+        //
+        EXPECT_ROCSPARSE_STATUS(rocsparse_spgeam(PARAMS(rocsparse_spgeam_stage_compute)),
+                                rocsparse_status_invalid_value);
+
+        ROCSPARSE_DEBUG_VERBOSE_ON;
+    }
+
+    //
+    // Call numeric_compute
+    //
+    CHECK_ROCSPARSE_ERROR(rocsparse_spgeam(PARAMS(rocsparse_spgeam_stage_numeric_compute)));
+
+    //
+    // Call numeric_compute twice
+    //
+    CHECK_ROCSPARSE_ERROR(rocsparse_spgeam(PARAMS(rocsparse_spgeam_stage_numeric_compute)));
+
+    {
+        ROCSPARSE_DEBUG_VERBOSE_OFF;
+        //
+        // Expect an invalid status when calling symbolic_compute after numeric_compute
+        //
+        EXPECT_ROCSPARSE_STATUS(rocsparse_spgeam(PARAMS(rocsparse_spgeam_stage_symbolic_compute)),
+                                rocsparse_status_invalid_value);
+
+        //
+        // Expect an invalid status when calling compute after numeric_compute
+        //
+        EXPECT_ROCSPARSE_STATUS(rocsparse_spgeam(PARAMS(rocsparse_spgeam_stage_compute)),
+                                rocsparse_status_invalid_value);
+
+        ROCSPARSE_DEBUG_VERBOSE_ON;
+    }
+
+    CHECK_ROCSPARSE_ERROR(rocsparse_destroy_spgeam_descr(descr));
+#undef PARAMS
+}
+
+void testing_spgeam_reuse_csr_extra(const Arguments& arg)
+{
+    testing_spgeam_reuse_csr_extra_wrong_stages(arg);
+}

--- a/clients/testings/testing_spgeam_reuse_csr.cpp
+++ b/clients/testings/testing_spgeam_reuse_csr.cpp
@@ -595,13 +595,6 @@ static void testing_spgeam_reuse_csr_extra_wrong_stages(const Arguments& arg)
         //
         EXPECT_ROCSPARSE_STATUS(rocsparse_spgeam(PARAMS(rocsparse_spgeam_stage_symbolic_compute)),
                                 rocsparse_status_invalid_value);
-
-        //
-        // Expect an invalid status when calling numeric_compute before analysis
-        //
-        EXPECT_ROCSPARSE_STATUS(rocsparse_spgeam(PARAMS(rocsparse_spgeam_stage_numeric_compute)),
-                                rocsparse_status_invalid_value);
-
         ROCSPARSE_DEBUG_VERBOSE_ON;
     }
 

--- a/clients/testings/testing_spgeam_reuse_csr_2.cpp
+++ b/clients/testings/testing_spgeam_reuse_csr_2.cpp
@@ -153,11 +153,10 @@ void testing_spgeam_reuse_csr_2(const Arguments& arg)
                                                        mat_A,
                                                        mat_B,
                                                        mat_C,
-                                                       rocsparse_spgeam_stage_symbolic,
+                                                       rocsparse_spgeam_stage_symbolic_compute,
                                                        &buffer_size_in_bytes,
                                                        nullptr));
     CHECK_HIP_ERROR(rocsparse_hipMalloc(&buffer, buffer_size_in_bytes));
-    CHECK_ROCSPARSE_ERROR(rocsparse_set_pointer_mode(handle, rocsparse_pointer_mode_host));
     CHECK_ROCSPARSE_ERROR(rocsparse_spgeam(handle,
                                            descr,
                                            h_alpha_ptr,
@@ -165,19 +164,7 @@ void testing_spgeam_reuse_csr_2(const Arguments& arg)
                                            h_beta_ptr,
                                            mat_B,
                                            mat_C,
-                                           rocsparse_spgeam_stage_symbolic,
-                                           buffer_size_in_bytes,
-                                           buffer,
-                                           nullptr));
-    CHECK_ROCSPARSE_ERROR(rocsparse_set_pointer_mode(handle, rocsparse_pointer_mode_device));
-    CHECK_ROCSPARSE_ERROR(rocsparse_spgeam(handle,
-                                           descr,
-                                           d_alpha_ptr,
-                                           mat_A,
-                                           d_beta_ptr,
-                                           mat_B,
-                                           mat_C,
-                                           rocsparse_spgeam_stage_symbolic,
+                                           rocsparse_spgeam_stage_symbolic_compute,
                                            buffer_size_in_bytes,
                                            buffer,
                                            nullptr));
@@ -189,7 +176,7 @@ void testing_spgeam_reuse_csr_2(const Arguments& arg)
                                                        mat_A,
                                                        mat_B,
                                                        mat_C,
-                                                       rocsparse_spgeam_stage_numeric,
+                                                       rocsparse_spgeam_stage_numeric_compute,
                                                        &buffer_size_in_bytes,
                                                        nullptr));
     CHECK_HIP_ERROR(rocsparse_hipMalloc(&buffer, buffer_size_in_bytes));
@@ -244,7 +231,7 @@ void testing_spgeam_reuse_csr_2(const Arguments& arg)
                                                    h_beta_ptr,
                                                    mat_B,
                                                    mat_C,
-                                                   rocsparse_spgeam_stage_numeric,
+                                                   rocsparse_spgeam_stage_numeric_compute,
                                                    buffer_size_in_bytes,
                                                    buffer,
                                                    nullptr));
@@ -268,7 +255,7 @@ void testing_spgeam_reuse_csr_2(const Arguments& arg)
                                                    d_beta_ptr,
                                                    mat_B,
                                                    mat_C,
-                                                   rocsparse_spgeam_stage_numeric,
+                                                   rocsparse_spgeam_stage_numeric_compute,
                                                    buffer_size_in_bytes,
                                                    buffer,
                                                    nullptr));
@@ -299,7 +286,7 @@ void testing_spgeam_reuse_csr_2(const Arguments& arg)
                                                    h_beta_ptr,
                                                    mat_B,
                                                    mat_C,
-                                                   rocsparse_spgeam_stage_numeric,
+                                                   rocsparse_spgeam_stage_numeric_compute,
                                                    buffer_size_in_bytes,
                                                    buffer,
                                                    nullptr));
@@ -317,7 +304,7 @@ void testing_spgeam_reuse_csr_2(const Arguments& arg)
                                                    h_beta_ptr,
                                                    mat_B,
                                                    mat_C,
-                                                   rocsparse_spgeam_stage_numeric,
+                                                   rocsparse_spgeam_stage_numeric_compute,
                                                    buffer_size_in_bytes,
                                                    buffer,
                                                    nullptr));

--- a/clients/tests/test_spgeam_csr.yaml
+++ b/clients/tests/test_spgeam_csr.yaml
@@ -48,13 +48,9 @@ Tests:
 
 - name: spgeam_csr_extra
   category: pre_checkin
-  transA: [rocsparse_operation_none]
-  transB: [rocsparse_operation_none]
-  baseA: [rocsparse_index_base_zero, rocsparse_index_base_one]
-  baseB: [rocsparse_index_base_zero, rocsparse_index_base_one]
-  baseC: [rocsparse_index_base_zero, rocsparse_index_base_one]
-  spgeam_alg: [rocsparse_spgeam_alg_default]
-  hardware: [gfx90a]
+  baseA: *all_rocsparse_index_base
+  baseB: *all_rocsparse_index_base
+  baseC: *all_rocsparse_index_base
   function: spgeam_csr_extra
 
 # C = alpha * A + beta * B

--- a/clients/tests/test_spgeam_reuse_csr.yaml
+++ b/clients/tests/test_spgeam_reuse_csr.yaml
@@ -220,3 +220,7 @@ Tests:
   matrix: [rocsparse_matrix_file_rocalution]
   spgeam_alg: [rocsparse_spgeam_alg_default]
   filename: [Chevron4]
+
+- name: spgeam_csr_extra
+  category: pre_checkin
+  function: spgeam_csr_extra

--- a/clients/tests/test_spgeam_reuse_csr.yaml
+++ b/clients/tests/test_spgeam_reuse_csr.yaml
@@ -221,6 +221,6 @@ Tests:
   spgeam_alg: [rocsparse_spgeam_alg_default]
   filename: [Chevron4]
 
-- name: spgeam_csr_extra
+- name: spgeam_reuse_csr_extra
   category: pre_checkin
-  function: spgeam_csr_extra
+  function: spgeam_reuse_csr_extra

--- a/library/include/internal/generic/rocsparse_spgeam.h
+++ b/library/include/internal/generic/rocsparse_spgeam.h
@@ -114,6 +114,7 @@ rocsparse_status rocsparse_spgeam_buffer_size(rocsparse_handle            handle
 *  \p rocsparse_spgeam. Once the computation is complete and the SpGEAM descriptor is no longer needed, the user must call
 *  \ref rocsparse_destroy_spgeam_descr. See full code example below.
 *
+*  The stage \ref rocsparse_spgeam_stage_compute computes the symbolic part and the numeric of the resulting matrix C. If the user wants to perform multiple operations involving matrices of same sparsity patterns but with different numerical values, then the stages \ref rocsparse_spgeam_stage_symbolic_compute and \ref rocsparse_spgeam_stage_numeric_compute can be used to separate the symbolic calculation from the numeric calculation. Note that the stage \ref rocsparse_spgeam_stage_compute cannot be mixed with the stages \ref rocsparse_spgeam_stage_symbolic_compute and \ref rocsparse_spgeam_stage_numeric_compute.
 *  \p rocsparse_spgeam supports multiple combinations of index types, data types, and compute types. The tables below indicate
 *  the currently supported different index and data types that can be used for the sparse matrices \f$op(A)\f$, \f$op(B)\f$, and
 *  \f$C\f$, and the compute type for \f$\alpha\f$ and \f$\beta\f$. The advantage of using different index and data types is to save on
@@ -196,7 +197,7 @@ rocsparse_status rocsparse_spgeam_buffer_size(rocsparse_handle            handle
 *  \retval rocsparse_status_invalid_pointer \p alpha and \p beta are invalid,
 *          \p mat_A, \p mat_B, \p mat_C, \p descr or \p buffer_size pointer is invalid.
 *
-*  \par Example
+*  \par First Example
 *  \code{.c}
 *   // A - m x n
 *   // B - m x n
@@ -362,6 +363,191 @@ rocsparse_status rocsparse_spgeam_buffer_size(rocsparse_handle            handle
 *   hipFree(dcsr_col_ind_C);
 *   hipFree(dcsr_val_C);
 *  \endcode
+*
+*
+*  \par Second Example
+*  \code{.c}
+*   // A - m x n
+*   // B - m x n
+*   // C - m x n
+*   int m = 4;
+*   int n = 6;
+*
+*   // 1 2 0 0 3 7
+*   // 0 0 1 4 6 8
+*   // 0 2 0 4 0 0
+*   // 9 8 0 0 2 0
+*   std::vector<int> hcsr_row_ptr_A = {0, 4, 8, 10, 13}; // host A m x n matrix
+*   std::vector<int> hcsr_col_ind_A = {0, 1, 4, 5, 2, 3, 4, 5, 1, 3, 0, 1, 4}; // host A m x n matrix
+*   std::vector<float> hcsr_val_A = {1, 2, 3, 7, 1, 4, 6, 8, 2, 4, 9, 8, 2};   // host A m x n matrix
+*
+*   // 0 2 1 0 0 5
+*   // 0 1 1 3 0 2
+*   // 0 0 0 0 0 0
+*   // 1 2 3 4 5 6
+*   std::vector<int> hcsr_row_ptr_B = {0, 3, 7, 7, 13}; // host B m x n matrix
+*   std::vector<int> hcsr_col_ind_B = {1, 2, 5, 1, 2, 3, 5, 0, 1, 2, 3, 4, 5}; // host B m x n matrix
+*   std::vector<float> hcsr_val_B = {2, 1, 5, 1, 1, 3, 2, 1, 2, 3, 4, 5, 6};   // host B m x n matrix
+*
+*   int nnz_A = hcsr_val_A.size();
+*   int nnz_B = hcsr_val_B.size();
+*
+*   float alpha            = 1.0f;
+*   float beta             = 1.0f;
+*
+*   int* dcsr_row_ptr_A = nullptr;
+*   int* dcsr_col_ind_A = nullptr;
+*   float* dcsr_val_A = nullptr;
+*
+*   int* dcsr_row_ptr_B = nullptr;
+*   int* dcsr_col_ind_B = nullptr;
+*   float* dcsr_val_B = nullptr;
+*
+*   hipMalloc((void**)&dcsr_row_ptr_A, (m + 1) * sizeof(int));
+*   hipMalloc((void**)&dcsr_col_ind_A, nnz_A * sizeof(int));
+*   hipMalloc((void**)&dcsr_val_A, nnz_A * sizeof(float));
+*
+*   hipMalloc((void**)&dcsr_row_ptr_B, (m + 1) * sizeof(int));
+*   hipMalloc((void**)&dcsr_col_ind_B, nnz_B * sizeof(int));
+*   hipMalloc((void**)&dcsr_val_B, nnz_B * sizeof(float));
+*
+*   hipMemcpy(dcsr_row_ptr_A, hcsr_row_ptr_A.data(), (m + 1) * sizeof(int), hipMemcpyHostToDevice);
+*   hipMemcpy(dcsr_col_ind_A, hcsr_col_ind_A.data(), nnz_A * sizeof(int), hipMemcpyHostToDevice);
+*   hipMemcpy(dcsr_val_A, hcsr_val_A.data(), nnz_A * sizeof(float), hipMemcpyHostToDevice);
+*
+*   hipMemcpy(dcsr_row_ptr_B, hcsr_row_ptr_B.data(), (m + 1) * sizeof(int), hipMemcpyHostToDevice);
+*   hipMemcpy(dcsr_col_ind_B, hcsr_col_ind_B.data(), nnz_B * sizeof(int), hipMemcpyHostToDevice);
+*   hipMemcpy(dcsr_val_B, hcsr_val_B.data(), nnz_B * sizeof(float), hipMemcpyHostToDevice);
+*
+*   rocsparse_handle     handle;
+*   rocsparse_error      p_error[1] = {};
+*   rocsparse_spmat_descr matA, matB, matC;
+*   rocsparse_index_base index_base = rocsparse_index_base_zero;
+*   rocsparse_indextype itype = rocsparse_indextype_i32;
+*   rocsparse_indextype jtype = rocsparse_indextype_i32;
+*   rocsparse_datatype  ttype = rocsparse_datatype_f32_r;
+*
+*   rocsparse_create_handle(&handle);
+*
+*   hipStream_t stream;
+*   rocsparse_get_stream(handle, &stream);
+*
+*   // Create sparse matrix A in CSR format
+*   rocsparse_create_csr_descr(&matA, m, n, nnz_A,
+*                       dcsr_row_ptr_A, dcsr_col_ind_A, dcsr_val_A,
+*                       itype, jtype,
+*                       index_base, ttype);
+*
+*   // Create sparse matrix B in CSR format
+*   rocsparse_create_csr_descr(&matB, m, n, nnz_B,
+*                       dcsr_row_ptr_B, dcsr_col_ind_B, dcsr_val_B,
+*                       itype, jtype,
+*                       index_base, ttype);
+*
+*   // Create SpGEAM descriptor.
+*   rocsparse_spgeam_descr descr;
+*   rocsparse_create_spgeam_descr(&descr);
+*
+*   // Set the algorithm on the descriptor
+*   const rocsparse_spgeam_alg alg = rocsparse_spgeam_alg_default;
+*   rocsparse_spgeam_set_input(handle, descr, rocsparse_spgeam_input_alg, &alg, sizeof(alg), p_error);
+*
+*   // Set the transpose operation for sparses matrix A and B on the descriptor
+*   const rocsparse_operation trans_A = rocsparse_operation_none;
+*   const rocsparse_operation trans_B = rocsparse_operation_none;
+*   rocsparse_spgeam_set_input(handle, descr, rocsparse_spgeam_input_operation_A, &trans_A, sizeof(trans_A), p_error);
+*   rocsparse_spgeam_set_input(handle, descr, rocsparse_spgeam_input_operation_B, &trans_B, sizeof(trans_B), p_error);
+*
+*   // Set the scalar type on the descriptor
+*   const rocsparse_datatype scalar_datatype = rocsparse_datatype_f32_r;
+*   rocsparse_spgeam_set_input(handle, descr, rocsparse_spgeam_input_scalar_datatype, &scalar_datatype, sizeof(scalar_datatype), p_error);
+*
+*   // Set the compute type on the descriptor
+*   const rocsparse_datatype compute_datatype = rocsparse_datatype_f32_r;
+*   rocsparse_spgeam_set_input(handle, descr, rocsparse_spgeam_input_compute_datatype, &compute_datatype, sizeof(compute_datatype), p_error);
+*
+*   // Calculate NNZ phase
+*   size_t buffer_size_in_bytes;
+*   void * buffer;
+*   rocsparse_spgeam_buffer_size(handle, descr, matA, matB, nullptr, rocsparse_spgeam_stage_analysis, &buffer_size_in_bytes, p_error);
+*
+*   hipMalloc(&buffer, buffer_size_in_bytes);
+*   rocsparse_spgeam(handle, descr, &alpha, matA, &beta, matB, nullptr, rocsparse_spgeam_stage_analysis, buffer_size_in_bytes, buffer, p_error);
+*   hipFree(buffer);
+*
+*   // Ensure analysis stage is complete before grabbing C non-zero count
+*   hipStreamSynchronize(stream);
+*
+*   int64_t nnz_C;
+*   rocsparse_spgeam_get_output(handle, descr, rocsparse_spgeam_output_nnz, &nnz_C, sizeof(int64_t), p_error);
+*
+*   // Compute column indices and values of C
+*   int* dcsr_row_ptr_C = nullptr;
+*   int* dcsr_col_ind_C = nullptr;
+*   float* dcsr_val_C = nullptr;
+*   hipMalloc((void**)&dcsr_row_ptr_C, (m + 1) * sizeof(int));
+*   hipMalloc((void**)&dcsr_col_ind_C, sizeof(int32_t) * nnz_C);
+*   hipMalloc((void**)&dcsr_val_C, sizeof(float) * nnz_C);
+*
+*   // Create sparse matrix C in CSR format
+*   rocsparse_create_csr_descr(&matC, m, n, nnz_C,
+*                       dcsr_row_ptr_C, dcsr_col_ind_C, dcsr_val_C,
+*                       itype, jtype,
+*                       index_base, ttype);
+*
+*   // Symbolic compute phase
+*   rocsparse_spgeam_buffer_size(handle, descr, matA, matB, matC, rocsparse_spgeam_stage_symbolic_compute, &buffer_size_in_bytes, p_error);
+*
+*   hipMalloc(&buffer, buffer_size_in_bytes);
+*   rocsparse_spgeam(handle, descr, &alpha, matA, &beta, matB, matC, rocsparse_spgeam_stage_symbolic_compute, buffer_size_in_bytes, buffer, p_error);
+*   hipFree(buffer);
+*
+*   // First Numeric compute phase
+*   rocsparse_spgeam_buffer_size(handle, descr, matA, matB, matC, rocsparse_spgeam_stage_numeric_compute, &buffer_size_in_bytes, p_error);
+*
+*   hipMalloc(&buffer, buffer_size_in_bytes);
+*   rocsparse_spgeam(handle, descr, &alpha, matA, &beta, matB, matC, rocsparse_spgeam_stage_numeric_compute, buffer_size_in_bytes, buffer, p_error);
+*   hipFree(buffer);
+*
+*
+*   // Second numeric compute phase
+*   hcsr_val_B[0] += 0.125;
+*   hcsr_val_B[1] += 0.5;
+*   hipMemcpy(dcsr_val_B, hcsr_val_B.data(), nnz_B * sizeof(float), hipMemcpyHostToDevice);
+*   hipMalloc(&buffer, buffer_size_in_bytes);
+*   rocsparse_spgeam(handle, descr, &alpha, matA, &beta, matB, matC, rocsparse_spgeam_stage_numeric_compute, buffer_size_in_bytes, buffer, p_error);
+*   hipFree(buffer);
+*
+*   // Copy C matrix result back to host
+*   std::vector<int> hcsr_row_ptr_C(m + 1);
+*   std::vector<int> hcsr_col_ind_C(nnz_C);
+*   std::vector<float>  hcsr_val_C(nnz_C);
+*
+*   hipMemcpy(hcsr_row_ptr_C.data(), dcsr_row_ptr_C, sizeof(int) * (m + 1), hipMemcpyDeviceToHost);
+*   hipMemcpy(hcsr_col_ind_C.data(), dcsr_col_ind_C, sizeof(int) * nnz_C, hipMemcpyDeviceToHost);
+*   hipMemcpy(hcsr_val_C.data(), dcsr_val_C, sizeof(float) * nnz_C, hipMemcpyDeviceToHost);
+*
+*   // Destroy matrix descriptors
+*   rocsparse_destroy_spmat_descr(matA);
+*   rocsparse_destroy_spmat_descr(matB);
+*   rocsparse_destroy_spmat_descr(matC);
+*   rocsparse_destroy_handle(handle);
+*   rocsparse_destroy_error(p_error[0]);
+*
+*   // Free device arrays
+*   hipFree(dcsr_row_ptr_A);
+*   hipFree(dcsr_col_ind_A);
+*   hipFree(dcsr_val_A);
+*
+*   hipFree(dcsr_row_ptr_B);
+*   hipFree(dcsr_col_ind_B);
+*   hipFree(dcsr_val_B);
+*
+*   hipFree(dcsr_row_ptr_C);
+*   hipFree(dcsr_col_ind_C);
+*   hipFree(dcsr_val_C);
+*  \endcode
+*
 */
 ROCSPARSE_EXPORT
 rocsparse_status rocsparse_spgeam(rocsparse_handle            handle,

--- a/library/include/rocsparse-types.h
+++ b/library/include/rocsparse-types.h
@@ -954,9 +954,9 @@ typedef enum rocsparse_spgeam_stage_
 {
     rocsparse_spgeam_stage_analysis = 1, /**< Computes number of non-zero entries. */
     rocsparse_spgeam_stage_compute  = 2, /**< Performs the actual SpGEAM computation. */
-    rocsparse_spgeam_stage_symbolic
+    rocsparse_spgeam_stage_symbolic_compute
     = 3, /**< Performs only the symbolic SpGEAM computation to fill the column indices array. */
-    rocsparse_spgeam_stage_numeric
+    rocsparse_spgeam_stage_numeric_compute
     = 4 /**< Performs only the numeric SpGEAM computation to fill the values array. */
 } rocsparse_spgeam_stage;
 

--- a/library/src/extra/rocsparse_spgeam.cpp
+++ b/library/src/extra/rocsparse_spgeam.cpp
@@ -548,28 +548,8 @@ namespace rocsparse
 
         case rocsparse_spgeam_stage_numeric_compute:
         {
-            if(previous_stage == ((rocsparse_spgeam_stage)-1))
-            {
-                RETURN_WITH_MESSAGE_IF_ROCSPARSE_ERROR(
-                    rocsparse_status_invalid_value,
-                    "invalid stage, the stage rocsparse_spgeam_stage_analysis must be executed "
-                    "before "
-                    "the stage rocsparse_spgeam_stage_numeric_compute");
-            }
-
             switch(previous_stage)
             {
-
-            case rocsparse_spgeam_stage_analysis:
-            {
-                RETURN_WITH_MESSAGE_IF_ROCSPARSE_ERROR(
-                    rocsparse_status_invalid_value,
-                    "invalid stage, the stage rocsparse_spgeam_stage_symbolic_compute must be "
-                    "executed "
-                    "before "
-                    "the stage rocsparse_spgeam_stage_numeric_compute");
-            }
-
             case rocsparse_spgeam_stage_compute:
             {
                 RETURN_WITH_MESSAGE_IF_ROCSPARSE_ERROR(
@@ -579,6 +559,7 @@ namespace rocsparse
                     "after the stage rocsparse_spgeam_stage_compute");
             }
 
+            case rocsparse_spgeam_stage_analysis:
             case rocsparse_spgeam_stage_numeric_compute:
             case rocsparse_spgeam_stage_symbolic_compute:
             {

--- a/library/src/extra/rocsparse_spgeam.cpp
+++ b/library/src/extra/rocsparse_spgeam.cpp
@@ -124,8 +124,8 @@ const char* rocsparse::enum_utils::to_string(rocsparse_spgeam_stage value_)
     {
         CASE(rocsparse_spgeam_stage_analysis);
         CASE(rocsparse_spgeam_stage_compute);
-        CASE(rocsparse_spgeam_stage_symbolic);
-        CASE(rocsparse_spgeam_stage_numeric);
+        CASE(rocsparse_spgeam_stage_symbolic_compute);
+        CASE(rocsparse_spgeam_stage_numeric_compute);
 #undef CASE
     }
     THROW_IF_ROCSPARSE_ERROR(rocsparse_status_invalid_value);
@@ -183,8 +183,8 @@ bool rocsparse::enum_utils::is_invalid(rocsparse_spgeam_stage value_)
     {
     case rocsparse_spgeam_stage_analysis:
     case rocsparse_spgeam_stage_compute:
-    case rocsparse_spgeam_stage_symbolic:
-    case rocsparse_spgeam_stage_numeric:
+    case rocsparse_spgeam_stage_symbolic_compute:
+    case rocsparse_spgeam_stage_numeric_compute:
     {
         return false;
     }
@@ -327,8 +327,8 @@ namespace rocsparse
             }
         }
         case rocsparse_spgeam_stage_compute:
-        case rocsparse_spgeam_stage_symbolic:
-        case rocsparse_spgeam_stage_numeric:
+        case rocsparse_spgeam_stage_symbolic_compute:
+        case rocsparse_spgeam_stage_numeric_compute:
         {
             *buffer_size = 0;
             return rocsparse_status_success;
@@ -415,8 +415,9 @@ namespace rocsparse
         ROCSPARSE_CHECKARG_POINTER(1, descr);
         ROCSPARSE_CHECKARG_POINTER(3, mat_A);
         ROCSPARSE_CHECKARG_POINTER(5, mat_B);
-        if(stage == rocsparse_spgeam_stage_compute || stage == rocsparse_spgeam_stage_symbolic
-           || stage == rocsparse_spgeam_stage_numeric)
+        if(stage == rocsparse_spgeam_stage_compute
+           || stage == rocsparse_spgeam_stage_symbolic_compute
+           || stage == rocsparse_spgeam_stage_numeric_compute)
         {
             ROCSPARSE_CHECKARG_POINTER(6, mat_C);
         }
@@ -446,8 +447,9 @@ namespace rocsparse
         ROCSPARSE_CHECKARG(
             5, mat_B, (mat_B->col_type != mat_A->col_type), rocsparse_status_type_mismatch);
 
-        if(stage == rocsparse_spgeam_stage_compute || stage == rocsparse_spgeam_stage_symbolic
-           || stage == rocsparse_spgeam_stage_numeric || mat_C != nullptr)
+        if(stage == rocsparse_spgeam_stage_compute
+           || stage == rocsparse_spgeam_stage_symbolic_compute
+           || stage == rocsparse_spgeam_stage_numeric_compute || mat_C != nullptr)
         {
             ROCSPARSE_CHECKARG(6, mat_C, (mat_C->init == false), rocsparse_status_not_initialized);
 
@@ -490,12 +492,116 @@ namespace rocsparse
                            rocsparse::enum_utils::is_invalid(descr->get_scalar_datatype()),
                            rocsparse_status_invalid_value);
 
+        const rocsparse_spgeam_stage previous_stage = descr->get_stage();
         // Validate the stage.
         switch(stage)
         {
+        case rocsparse_spgeam_stage_symbolic_compute:
+        {
+
+            if(previous_stage == ((rocsparse_spgeam_stage)-1))
+            {
+                RETURN_WITH_MESSAGE_IF_ROCSPARSE_ERROR(
+                    rocsparse_status_invalid_value,
+                    "invalid stage, the stage rocsparse_spgeam_stage_analysis must be executed "
+                    "before "
+                    "the stage rocsparse_spgeam_stage_symbolic_compute");
+            }
+
+            switch(previous_stage)
+            {
+
+            case rocsparse_spgeam_stage_analysis:
+            {
+                break;
+            }
+
+            case rocsparse_spgeam_stage_compute:
+            {
+                RETURN_WITH_MESSAGE_IF_ROCSPARSE_ERROR(
+                    rocsparse_status_invalid_value,
+                    "invalid stage, the stage rocsparse_spgeam_stage_symbolic_compute cannot be "
+                    "called "
+                    "after the stage rocsparse_spgeam_stage_compute");
+            }
+
+            case rocsparse_spgeam_stage_numeric_compute:
+            {
+                RETURN_WITH_MESSAGE_IF_ROCSPARSE_ERROR(
+                    rocsparse_status_invalid_value,
+                    "invalid stage, the stage rocsparse_spgeam_stage_symbolic_compute cannot be "
+                    "called "
+                    "after the stage rocsparse_spgeam_stage_numeric_compute");
+            }
+
+            case rocsparse_spgeam_stage_symbolic_compute:
+            {
+                RETURN_WITH_MESSAGE_IF_ROCSPARSE_ERROR(
+                    rocsparse_status_invalid_value,
+                    "invalid stage, the stage rocsparse_spgeam_stage_symbolic_compute has already "
+                    "been "
+                    "executed");
+            }
+            }
+            break;
+        }
+
+        case rocsparse_spgeam_stage_numeric_compute:
+        {
+            if(previous_stage == ((rocsparse_spgeam_stage)-1))
+            {
+                RETURN_WITH_MESSAGE_IF_ROCSPARSE_ERROR(
+                    rocsparse_status_invalid_value,
+                    "invalid stage, the stage rocsparse_spgeam_stage_analysis must be executed "
+                    "before "
+                    "the stage rocsparse_spgeam_stage_numeric_compute");
+            }
+
+            switch(previous_stage)
+            {
+
+            case rocsparse_spgeam_stage_analysis:
+            {
+                RETURN_WITH_MESSAGE_IF_ROCSPARSE_ERROR(
+                    rocsparse_status_invalid_value,
+                    "invalid stage, the stage rocsparse_spgeam_stage_symbolic_compute must be "
+                    "executed "
+                    "before "
+                    "the stage rocsparse_spgeam_stage_numeric_compute");
+            }
+
+            case rocsparse_spgeam_stage_compute:
+            {
+                RETURN_WITH_MESSAGE_IF_ROCSPARSE_ERROR(
+                    rocsparse_status_invalid_value,
+                    "invalid stage, the stage rocsparse_spgeam_stage_numeric_compute cannot be "
+                    "called "
+                    "after the stage rocsparse_spgeam_stage_compute");
+            }
+
+            case rocsparse_spgeam_stage_numeric_compute:
+            case rocsparse_spgeam_stage_symbolic_compute:
+            {
+                break;
+            }
+            }
+
+            break;
+        }
+
         case rocsparse_spgeam_stage_analysis:
         {
-            if(descr->get_stage() == rocsparse_spgeam_stage_compute)
+            switch(previous_stage)
+            {
+            case rocsparse_spgeam_stage_analysis:
+            {
+                RETURN_WITH_MESSAGE_IF_ROCSPARSE_ERROR(
+                    rocsparse_status_invalid_value,
+                    "invalid stage, the stage rocsparse_spgeam_stage_analysis has already been "
+                    "executed");
+            }
+
+            case rocsparse_spgeam_stage_compute:
             {
                 RETURN_WITH_MESSAGE_IF_ROCSPARSE_ERROR(
                     rocsparse_status_invalid_value,
@@ -503,18 +609,32 @@ namespace rocsparse
                     "after "
                     "the stage rocsparse_spgeam_stage_compute");
             }
-            else if(descr->get_stage() == rocsparse_spgeam_stage_analysis)
+
+            case rocsparse_spgeam_stage_numeric_compute:
             {
                 RETURN_WITH_MESSAGE_IF_ROCSPARSE_ERROR(
                     rocsparse_status_invalid_value,
-                    "invalid stage, the stage rocsparse_spgeam_stage_analysis has already been "
-                    "executed");
+                    "invalid stage, the stage rocsparse_spgeam_stage_analysis cannot be called "
+                    "after "
+                    "the stage rocsparse_spgeam_stage_numeric_compute");
             }
+
+            case rocsparse_spgeam_stage_symbolic_compute:
+            {
+                RETURN_WITH_MESSAGE_IF_ROCSPARSE_ERROR(
+                    rocsparse_status_invalid_value,
+                    "invalid stage, the stage rocsparse_spgeam_stage_analysis cannot be called "
+                    "after "
+                    "the stage rocsparse_spgeam_stage_symbolic_compute");
+            }
+            }
+
             break;
         }
+
         case rocsparse_spgeam_stage_compute:
         {
-            if(descr->get_stage() == ((rocsparse_spgeam_stage)-1))
+            if(previous_stage == ((rocsparse_spgeam_stage)-1))
             {
                 RETURN_WITH_MESSAGE_IF_ROCSPARSE_ERROR(
                     rocsparse_status_invalid_value,
@@ -522,6 +642,32 @@ namespace rocsparse
                     "before "
                     "the stage rocsparse_spgeam_stage_compute");
             }
+
+            switch(previous_stage)
+            {
+            case rocsparse_spgeam_stage_analysis:
+            case rocsparse_spgeam_stage_compute:
+            {
+                break;
+            }
+
+            case rocsparse_spgeam_stage_numeric_compute:
+            {
+                RETURN_WITH_MESSAGE_IF_ROCSPARSE_ERROR(
+                    rocsparse_status_invalid_value,
+                    "invalid stage, the stage rocsparse_spgeam_stage_compute cannot be called "
+                    "after the stage rocsparse_spgeam_stage_numeric_compute");
+            }
+
+            case rocsparse_spgeam_stage_symbolic_compute:
+            {
+                RETURN_WITH_MESSAGE_IF_ROCSPARSE_ERROR(
+                    rocsparse_status_invalid_value,
+                    "invalid stage, the stage rocsparse_spgeam_stage_compute cannot be called "
+                    "after the stage rocsparse_spgeam_stage_symbolic_compute");
+            }
+            }
+
             break;
         }
         }
@@ -670,7 +816,7 @@ namespace rocsparse
             }
         }
 
-        case rocsparse_spgeam_stage_symbolic:
+        case rocsparse_spgeam_stage_symbolic_compute:
         {
             switch(format_A)
             {
@@ -722,7 +868,7 @@ namespace rocsparse
             }
         }
 
-        case rocsparse_spgeam_stage_numeric:
+        case rocsparse_spgeam_stage_numeric_compute:
         {
             const void* local_alpha = alpha;
             const void* local_beta  = beta;


### PR DESCRIPTION
Summary of proposed changes:
- fixing missing switch statements on rocsparse_spgeam_stage in argument checking
- Implement a policy to prevent mixing stages
- rename rocsparse_spgeam_stage_symbolic with rocsparse_spgeam_stage_symbolic_compute
- rename rocsparse_spgeam_stage_numeric with rocsparse_spgeam_stage_symbolic_numeric
- tests the new policy to prevent mixing stages
