### PR TITLE
spgeam final fix

### DIFF
--- a/clients/samples/example_spgeam.cpp
+++ b/clients/samples/example_spgeam.cpp
@@ -222,9 +222,7 @@ int main(int argc, char* argv[])
     HIP_CHECK(hipMalloc(&buffer, buffer_size_in_bytes));
     ROCSPARSE_CHECK(rocsparse_spgeam(handle,
                                      descr,
-                                     &alpha,
                                      A,
-                                     &beta,
                                      B,
                                      nullptr,
                                      rocsparse_spgeam_stage_analysis,
@@ -259,11 +257,15 @@ int main(int argc, char* argv[])
         handle, descr, A, B, C, rocsparse_spgeam_stage_compute, &buffer_size_in_bytes, nullptr));
 
     HIP_CHECK(hipMalloc(&buffer, buffer_size_in_bytes));
+
+    ROCSPARSE_CHECK(rocsparse_spgeam_set_input(
+        handle, descr, rocsparse_spgeam_input_scalar_A, &alpha, sizeof(&alpha), nullptr));
+    ROCSPARSE_CHECK(rocsparse_spgeam_set_input(
+        handle, descr, rocsparse_spgeam_input_scalar_B, &beta, sizeof(&beta), nullptr));
+
     ROCSPARSE_CHECK(rocsparse_spgeam(handle,
                                      descr,
-                                     &alpha,
                                      A,
-                                     &beta,
                                      B,
                                      C,
                                      rocsparse_spgeam_stage_compute,

--- a/clients/samples/example_spgeam.cpp
+++ b/clients/samples/example_spgeam.cpp
@@ -259,9 +259,9 @@ int main(int argc, char* argv[])
     HIP_CHECK(hipMalloc(&buffer, buffer_size_in_bytes));
 
     ROCSPARSE_CHECK(rocsparse_spgeam_set_input(
-        handle, descr, rocsparse_spgeam_input_scalar_A, &alpha, sizeof(&alpha), nullptr));
+        handle, descr, rocsparse_spgeam_input_scalar_alpha, &alpha, sizeof(&alpha), nullptr));
     ROCSPARSE_CHECK(rocsparse_spgeam_set_input(
-        handle, descr, rocsparse_spgeam_input_scalar_B, &beta, sizeof(&beta), nullptr));
+        handle, descr, rocsparse_spgeam_input_scalar_beta, &beta, sizeof(&beta), nullptr));
 
     ROCSPARSE_CHECK(rocsparse_spgeam(handle,
                                      descr,

--- a/clients/samples/example_spgeam_2.cpp
+++ b/clients/samples/example_spgeam_2.cpp
@@ -243,9 +243,9 @@ int main(int argc, char* argv[])
 
     HIP_CHECK(hipMalloc(&buffer, buffer_size_in_bytes));
     ROCSPARSE_CHECK(rocsparse_spgeam_set_input(
-        handle, descr, rocsparse_spgeam_input_scalar_A, &alpha, sizeof(&alpha), nullptr));
+        handle, descr, rocsparse_spgeam_input_scalar_alpha, &alpha, sizeof(&alpha), nullptr));
     ROCSPARSE_CHECK(rocsparse_spgeam_set_input(
-        handle, descr, rocsparse_spgeam_input_scalar_B, &beta, sizeof(&beta), nullptr));
+        handle, descr, rocsparse_spgeam_input_scalar_beta, &beta, sizeof(&beta), nullptr));
 
     ROCSPARSE_CHECK(rocsparse_spgeam(handle,
                                      descr,

--- a/clients/samples/example_spgeam_2.cpp
+++ b/clients/samples/example_spgeam_2.cpp
@@ -210,9 +210,7 @@ int main(int argc, char* argv[])
     HIP_CHECK(hipMalloc(&buffer, buffer_size_in_bytes));
     ROCSPARSE_CHECK(rocsparse_spgeam(handle,
                                      descr,
-                                     &alpha,
                                      A,
-                                     &beta,
                                      B,
                                      C,
                                      rocsparse_spgeam_stage_analysis,
@@ -244,12 +242,14 @@ int main(int argc, char* argv[])
         handle, descr, A, B, C, rocsparse_spgeam_stage_compute, &buffer_size_in_bytes, nullptr));
 
     HIP_CHECK(hipMalloc(&buffer, buffer_size_in_bytes));
+    ROCSPARSE_CHECK(rocsparse_spgeam_set_input(
+        handle, descr, rocsparse_spgeam_input_scalar_A, &alpha, sizeof(&alpha), nullptr));
+    ROCSPARSE_CHECK(rocsparse_spgeam_set_input(
+        handle, descr, rocsparse_spgeam_input_scalar_B, &beta, sizeof(&beta), nullptr));
 
     ROCSPARSE_CHECK(rocsparse_spgeam(handle,
                                      descr,
-                                     &alpha,
                                      A,
-                                     &beta,
                                      B,
                                      C,
                                      rocsparse_spgeam_stage_compute,

--- a/clients/samples/example_spgeam_3.cpp
+++ b/clients/samples/example_spgeam_3.cpp
@@ -298,9 +298,9 @@ int main(int argc, char* argv[])
     HIP_CHECK(hipMalloc(&buffer, buffer_size_in_bytes));
 
     ROCSPARSE_CHECK(rocsparse_spgeam_set_input(
-        handle, descr, rocsparse_spgeam_input_scalar_A, &alpha, sizeof(&alpha), nullptr));
+        handle, descr, rocsparse_spgeam_input_scalar_alpha, &alpha, sizeof(&alpha), nullptr));
     ROCSPARSE_CHECK(rocsparse_spgeam_set_input(
-        handle, descr, rocsparse_spgeam_input_scalar_B, &beta, sizeof(&beta), nullptr));
+        handle, descr, rocsparse_spgeam_input_scalar_beta, &beta, sizeof(&beta), nullptr));
 
     ROCSPARSE_CHECK(rocsparse_spgeam(handle,
                                      descr,
@@ -391,9 +391,9 @@ int main(int argc, char* argv[])
     HIP_CHECK(hipMalloc(&buffer, buffer_size_in_bytes));
 
     ROCSPARSE_CHECK(rocsparse_spgeam_set_input(
-        handle, descr, rocsparse_spgeam_input_scalar_A, &alpha, sizeof(&alpha), nullptr));
+        handle, descr, rocsparse_spgeam_input_scalar_alpha, &alpha, sizeof(&alpha), nullptr));
     ROCSPARSE_CHECK(rocsparse_spgeam_set_input(
-        handle, descr, rocsparse_spgeam_input_scalar_B, &beta, sizeof(&beta), nullptr));
+        handle, descr, rocsparse_spgeam_input_scalar_beta, &beta, sizeof(&beta), nullptr));
 
     ROCSPARSE_CHECK(rocsparse_spgeam(handle,
                                      descr,

--- a/clients/samples/example_spgeam_3.cpp
+++ b/clients/samples/example_spgeam_3.cpp
@@ -205,19 +205,17 @@ int main(int argc, char* argv[])
                                                  A,
                                                  B,
                                                  nullptr,
-                                                 rocsparse_spgeam_stage_analysis,
+                                                 rocsparse_spgeam_stage_symbolic_analysis,
                                                  &buffer_size_in_bytes,
                                                  nullptr));
 
     HIP_CHECK(hipMalloc(&buffer, buffer_size_in_bytes));
     ROCSPARSE_CHECK(rocsparse_spgeam(handle,
                                      descr,
-                                     &alpha,
                                      A,
-                                     &beta,
                                      B,
                                      nullptr,
-                                     rocsparse_spgeam_stage_analysis,
+                                     rocsparse_spgeam_stage_symbolic_analysis,
                                      buffer_size_in_bytes,
                                      buffer,
                                      nullptr));
@@ -257,9 +255,7 @@ int main(int argc, char* argv[])
     HIP_CHECK(hipMalloc(&buffer, buffer_size_in_bytes));
     ROCSPARSE_CHECK(rocsparse_spgeam(handle,
                                      descr,
-                                     &alpha,
                                      A,
-                                     &beta,
                                      B,
                                      C,
                                      rocsparse_spgeam_stage_symbolic_compute,
@@ -274,16 +270,41 @@ int main(int argc, char* argv[])
                                                  A,
                                                  B,
                                                  C,
-                                                 rocsparse_spgeam_stage_numeric_compute,
+                                                 rocsparse_spgeam_stage_numeric_analysis,
                                                  &buffer_size_in_bytes,
                                                  nullptr));
 
     HIP_CHECK(hipMalloc(&buffer, buffer_size_in_bytes));
     ROCSPARSE_CHECK(rocsparse_spgeam(handle,
                                      descr,
-                                     &alpha,
                                      A,
-                                     &beta,
+                                     B,
+                                     C,
+                                     rocsparse_spgeam_stage_numeric_analysis,
+                                     buffer_size_in_bytes,
+                                     buffer,
+                                     nullptr));
+    HIP_CHECK(hipFree(buffer));
+
+    ROCSPARSE_CHECK(rocsparse_spgeam_buffer_size(handle,
+                                                 descr,
+                                                 A,
+                                                 B,
+                                                 C,
+                                                 rocsparse_spgeam_stage_numeric_compute,
+                                                 &buffer_size_in_bytes,
+                                                 nullptr));
+
+    HIP_CHECK(hipMalloc(&buffer, buffer_size_in_bytes));
+
+    ROCSPARSE_CHECK(rocsparse_spgeam_set_input(
+        handle, descr, rocsparse_spgeam_input_scalar_A, &alpha, sizeof(&alpha), nullptr));
+    ROCSPARSE_CHECK(rocsparse_spgeam_set_input(
+        handle, descr, rocsparse_spgeam_input_scalar_B, &beta, sizeof(&beta), nullptr));
+
+    ROCSPARSE_CHECK(rocsparse_spgeam(handle,
+                                     descr,
+                                     A,
                                      B,
                                      C,
                                      rocsparse_spgeam_stage_numeric_compute,
@@ -341,17 +362,42 @@ int main(int argc, char* argv[])
                                                  A,
                                                  B,
                                                  C,
+                                                 rocsparse_spgeam_stage_numeric_analysis,
+                                                 &buffer_size_in_bytes,
+                                                 nullptr));
+
+    HIP_CHECK(hipMalloc(&buffer, buffer_size_in_bytes));
+    ROCSPARSE_CHECK(rocsparse_spgeam(handle,
+                                     descr,
+                                     A,
+                                     B,
+                                     C,
+                                     rocsparse_spgeam_stage_numeric_analysis,
+                                     buffer_size_in_bytes,
+                                     buffer,
+                                     nullptr));
+    HIP_CHECK(hipFree(buffer));
+
+    ROCSPARSE_CHECK(rocsparse_spgeam_buffer_size(handle,
+                                                 descr,
+                                                 A,
+                                                 B,
+                                                 C,
                                                  rocsparse_spgeam_stage_numeric_compute,
                                                  &buffer_size_in_bytes,
                                                  nullptr));
 
     // Numerical compute phase
     HIP_CHECK(hipMalloc(&buffer, buffer_size_in_bytes));
+
+    ROCSPARSE_CHECK(rocsparse_spgeam_set_input(
+        handle, descr, rocsparse_spgeam_input_scalar_A, &alpha, sizeof(&alpha), nullptr));
+    ROCSPARSE_CHECK(rocsparse_spgeam_set_input(
+        handle, descr, rocsparse_spgeam_input_scalar_B, &beta, sizeof(&beta), nullptr));
+
     ROCSPARSE_CHECK(rocsparse_spgeam(handle,
                                      descr,
-                                     &alpha,
                                      A,
-                                     &beta,
                                      B,
                                      C,
                                      rocsparse_spgeam_stage_numeric_compute,

--- a/clients/testings/testing_spgeam_csr.cpp
+++ b/clients/testings/testing_spgeam_csr.cpp
@@ -306,14 +306,14 @@ void testing_spgeam_csr(const Arguments& arg)
 
         CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(handle,
                                                          descr,
-                                                         rocsparse_spgeam_input_scalar_A,
+                                                         rocsparse_spgeam_input_scalar_alpha,
                                                          h_alpha_ptr,
                                                          sizeof(h_alpha_ptr),
                                                          nullptr));
 
         CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(handle,
                                                          descr,
-                                                         rocsparse_spgeam_input_scalar_B,
+                                                         rocsparse_spgeam_input_scalar_beta,
                                                          h_beta_ptr,
                                                          sizeof(h_beta_ptr),
                                                          nullptr));
@@ -341,14 +341,14 @@ void testing_spgeam_csr(const Arguments& arg)
         CHECK_ROCSPARSE_ERROR(rocsparse_set_pointer_mode(handle, rocsparse_pointer_mode_device));
         CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(handle,
                                                          descr,
-                                                         rocsparse_spgeam_input_scalar_A,
+                                                         rocsparse_spgeam_input_scalar_alpha,
                                                          d_alpha_ptr,
                                                          sizeof(d_alpha_ptr),
                                                          nullptr));
 
         CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(handle,
                                                          descr,
-                                                         rocsparse_spgeam_input_scalar_B,
+                                                         rocsparse_spgeam_input_scalar_beta,
                                                          d_beta_ptr,
                                                          sizeof(d_beta_ptr),
                                                          nullptr));
@@ -381,14 +381,14 @@ void testing_spgeam_csr(const Arguments& arg)
 
         CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(handle,
                                                          descr,
-                                                         rocsparse_spgeam_input_scalar_A,
+                                                         rocsparse_spgeam_input_scalar_alpha,
                                                          h_alpha_ptr,
                                                          sizeof(h_alpha_ptr),
                                                          nullptr));
 
         CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(handle,
                                                          descr,
-                                                         rocsparse_spgeam_input_scalar_B,
+                                                         rocsparse_spgeam_input_scalar_beta,
                                                          h_beta_ptr,
                                                          sizeof(h_beta_ptr),
                                                          nullptr));
@@ -684,10 +684,10 @@ static void testing_spgeam_csr_extra_wrong_stages(const Arguments& arg)
         handle, descr, rocsparse_spgeam_input_compute_datatype, &ttype, sizeof(ttype), nullptr));
 
     CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(
-        handle, descr, rocsparse_spgeam_input_scalar_A, &h_alpha, sizeof(&h_alpha), nullptr));
+        handle, descr, rocsparse_spgeam_input_scalar_alpha, &h_alpha, sizeof(&h_alpha), nullptr));
 
     CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(
-        handle, descr, rocsparse_spgeam_input_scalar_B, &h_beta, sizeof(&h_beta), nullptr));
+        handle, descr, rocsparse_spgeam_input_scalar_beta, &h_beta, sizeof(&h_beta), nullptr));
 
     // Calculate NNZ phase
     const size_t              buffer_size_in_bytes = 64;

--- a/clients/testings/testing_spgeam_csr.cpp
+++ b/clients/testings/testing_spgeam_csr.cpp
@@ -69,20 +69,17 @@ void testing_spgeam_csr_bad_arg(const Arguments& arg)
     rocsparse_spmat_descr mat_B = local_B;
     rocsparse_spmat_descr mat_C = local_C;
 
-    const T* alpha = (const T*)0x4;
-    const T* beta  = (const T*)0x4;
-
     size_t buffer_size = 0;
     void*  temp_buffer = nullptr;
 
     int32_t       nargs_to_exclude_buffer_size   = 3;
     const int32_t args_to_exclude_buffer_size[3] = {4, 6, 7};
 
-    int32_t       nargs_to_exclude_analysis   = 6;
-    const int32_t args_to_exclude_analysis[6] = {2, 4, 6, 8, 9, 10};
+    int32_t       nargs_to_exclude_analysis   = 4;
+    const int32_t args_to_exclude_analysis[4] = {4, 6, 7, 8};
 
-    int32_t       nargs_to_exclude_compute   = 5;
-    const int32_t args_to_exclude_compute[5] = {2, 4, 8, 9, 10};
+    int32_t       nargs_to_exclude_compute   = 3;
+    const int32_t args_to_exclude_compute[3] = {6, 7, 8};
 
     rocsparse_spgeam_stage stage = rocsparse_spgeam_stage_analysis;
     rocsparse_error*       p_error{};
@@ -105,9 +102,7 @@ void testing_spgeam_csr_bad_arg(const Arguments& arg)
                             args_to_exclude_analysis,
                             handle,
                             descr,
-                            alpha,
                             mat_A,
-                            beta,
                             mat_B,
                             mat_C,
                             stage,
@@ -135,9 +130,7 @@ void testing_spgeam_csr_bad_arg(const Arguments& arg)
                             args_to_exclude_compute,
                             handle,
                             descr,
-                            alpha,
                             mat_A,
-                            beta,
                             mat_B,
                             mat_C,
                             stage,
@@ -161,16 +154,15 @@ void testing_spgeam_csr(const Arguments& arg)
     T h_alpha = arg.get_alpha<T>();
     T h_beta  = arg.get_beta<T>();
 
-    // -99 means nullptr
-    T* h_alpha_ptr = (h_alpha == (T)-99) ? nullptr : &h_alpha;
-    T* h_beta_ptr  = (h_beta == (T)-99) ? nullptr : &h_beta;
+    T* h_alpha_ptr = &h_alpha;
+    T* h_beta_ptr  = &h_beta;
 
     device_vector<T> d_alpha(1);
     device_vector<T> d_beta(1);
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
-    T* d_alpha_ptr = (h_alpha == (T)-99) ? nullptr : d_alpha;
-    T* d_beta_ptr  = (h_beta == (T)-99) ? nullptr : d_beta;
+    T* d_alpha_ptr = d_alpha;
+    T* d_beta_ptr  = d_beta;
 
     // Index and data type
     rocsparse_datatype ttype = get_datatype<T>();
@@ -238,9 +230,7 @@ void testing_spgeam_csr(const Arguments& arg)
     CHECK_ROCSPARSE_ERROR(rocsparse_set_pointer_mode(handle, rocsparse_pointer_mode_host));
     CHECK_ROCSPARSE_ERROR(rocsparse_spgeam(handle,
                                            descr,
-                                           h_alpha_ptr,
                                            mat_A,
-                                           h_beta_ptr,
                                            mat_B,
                                            nullptr,
                                            rocsparse_spgeam_stage_analysis,
@@ -261,7 +251,6 @@ void testing_spgeam_csr(const Arguments& arg)
     dC.define(M, N, nnz_C, base_C);
     rocsparse_local_spmat mat_C(dC);
 
-    // Compute phase
     CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_buffer_size(handle,
                                                        descr,
                                                        mat_A,
@@ -314,13 +303,26 @@ void testing_spgeam_csr(const Arguments& arg)
 
         // Compute C on host multiple times.
         CHECK_ROCSPARSE_ERROR(rocsparse_set_pointer_mode(handle, rocsparse_pointer_mode_host));
+
+        CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(handle,
+                                                         descr,
+                                                         rocsparse_spgeam_input_scalar_A,
+                                                         h_alpha_ptr,
+                                                         sizeof(h_alpha_ptr),
+                                                         nullptr));
+
+        CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(handle,
+                                                         descr,
+                                                         rocsparse_spgeam_input_scalar_B,
+                                                         h_beta_ptr,
+                                                         sizeof(h_beta_ptr),
+                                                         nullptr));
+
         for(int32_t i = 0; i < 2; i++)
         {
             CHECK_ROCSPARSE_ERROR(rocsparse_spgeam(handle,
                                                    descr,
-                                                   h_alpha_ptr,
                                                    mat_A,
-                                                   h_beta_ptr,
                                                    mat_B,
                                                    mat_C,
                                                    rocsparse_spgeam_stage_compute,
@@ -337,13 +339,24 @@ void testing_spgeam_csr(const Arguments& arg)
 
         // Compute C on device multiple times.
         CHECK_ROCSPARSE_ERROR(rocsparse_set_pointer_mode(handle, rocsparse_pointer_mode_device));
+        CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(handle,
+                                                         descr,
+                                                         rocsparse_spgeam_input_scalar_A,
+                                                         d_alpha_ptr,
+                                                         sizeof(d_alpha_ptr),
+                                                         nullptr));
+
+        CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(handle,
+                                                         descr,
+                                                         rocsparse_spgeam_input_scalar_B,
+                                                         d_beta_ptr,
+                                                         sizeof(d_beta_ptr),
+                                                         nullptr));
         for(int32_t i = 0; i < 2; i++)
         {
             CHECK_ROCSPARSE_ERROR(rocsparse_spgeam(handle,
                                                    descr,
-                                                   d_alpha_ptr,
                                                    mat_A,
-                                                   d_beta_ptr,
                                                    mat_B,
                                                    mat_C,
                                                    rocsparse_spgeam_stage_compute,
@@ -366,14 +379,26 @@ void testing_spgeam_csr(const Arguments& arg)
 
         CHECK_ROCSPARSE_ERROR(rocsparse_set_pointer_mode(handle, rocsparse_pointer_mode_host));
 
+        CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(handle,
+                                                         descr,
+                                                         rocsparse_spgeam_input_scalar_A,
+                                                         h_alpha_ptr,
+                                                         sizeof(h_alpha_ptr),
+                                                         nullptr));
+
+        CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(handle,
+                                                         descr,
+                                                         rocsparse_spgeam_input_scalar_B,
+                                                         h_beta_ptr,
+                                                         sizeof(h_beta_ptr),
+                                                         nullptr));
+
         // Warm up
         for(int32_t iter = 0; iter < number_cold_calls; ++iter)
         {
             CHECK_ROCSPARSE_ERROR(rocsparse_spgeam(handle,
                                                    descr,
-                                                   h_alpha_ptr,
                                                    mat_A,
-                                                   h_beta_ptr,
                                                    mat_B,
                                                    mat_C,
                                                    rocsparse_spgeam_stage_compute,
@@ -389,9 +414,7 @@ void testing_spgeam_csr(const Arguments& arg)
         {
             CHECK_ROCSPARSE_ERROR(rocsparse_spgeam(handle,
                                                    descr,
-                                                   h_alpha_ptr,
                                                    mat_A,
-                                                   h_beta_ptr,
                                                    mat_B,
                                                    mat_C,
                                                    rocsparse_spgeam_stage_compute,
@@ -468,8 +491,6 @@ static void testing_spgeam_csr_extra_expected_overflow(const Arguments& arg)
     const int32_t              n       = 50000;
     const int32_t              nnz_A   = (m / 2) * n;
     const int32_t              nnz_B   = (m / 2) * n;
-    const float                h_alpha = 1.0f;
-    const float                h_beta  = 1.0f;
     const rocsparse_index_base base_A  = arg.baseA;
     const rocsparse_index_base base_B  = arg.baseB;
     const rocsparse_index_base base_C  = arg.baseC;
@@ -571,9 +592,7 @@ static void testing_spgeam_csr_extra_expected_overflow(const Arguments& arg)
     CHECK_HIP_ERROR(rocsparse_hipMalloc(&buffer, buffer_size_in_bytes));
     CHECK_ROCSPARSE_ERROR(rocsparse_spgeam(handle,
                                            descr,
-                                           &h_alpha,
                                            A,
-                                           &h_beta,
                                            B,
                                            C,
                                            rocsparse_spgeam_stage_analysis,
@@ -664,12 +683,17 @@ static void testing_spgeam_csr_extra_wrong_stages(const Arguments& arg)
     CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(
         handle, descr, rocsparse_spgeam_input_compute_datatype, &ttype, sizeof(ttype), nullptr));
 
+    CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(
+        handle, descr, rocsparse_spgeam_input_scalar_A, &h_alpha, sizeof(&h_alpha), nullptr));
+
+    CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(
+        handle, descr, rocsparse_spgeam_input_scalar_B, &h_beta, sizeof(&h_beta), nullptr));
+
     // Calculate NNZ phase
     const size_t              buffer_size_in_bytes = 64;
     device_dense_vector<char> buffer(buffer_size_in_bytes);
 
-#define PARAMS(stage) \
-    handle, descr, &h_alpha, A, &h_beta, B, C, stage, buffer_size_in_bytes, buffer, nullptr
+#define PARAMS(stage) handle, descr, A, B, C, stage, buffer_size_in_bytes, buffer, nullptr
 
     //
     // Expect an invalid status when calling compute before analysis
@@ -697,6 +721,18 @@ static void testing_spgeam_csr_extra_wrong_stages(const Arguments& arg)
     }
 
     //
+    // Expect an invalid status when calling symbolic or numeric analysis after analysis
+    //
+    {
+        ROCSPARSE_DEBUG_VERBOSE_OFF;
+        EXPECT_ROCSPARSE_STATUS(rocsparse_spgeam(PARAMS(rocsparse_spgeam_stage_symbolic_analysis)),
+                                rocsparse_status_invalid_value);
+        EXPECT_ROCSPARSE_STATUS(rocsparse_spgeam(PARAMS(rocsparse_spgeam_stage_numeric_analysis)),
+                                rocsparse_status_invalid_value);
+        ROCSPARSE_DEBUG_VERBOSE_ON;
+    }
+
+    //
     // Call compute.
     //
     CHECK_ROCSPARSE_ERROR(rocsparse_spgeam(PARAMS(rocsparse_spgeam_stage_compute)));
@@ -716,6 +752,12 @@ static void testing_spgeam_csr_extra_wrong_stages(const Arguments& arg)
                                 rocsparse_status_invalid_value);
 
         //
+        // Expect an invalid status when calling symbolic analysis after compute
+        //
+        EXPECT_ROCSPARSE_STATUS(rocsparse_spgeam(PARAMS(rocsparse_spgeam_stage_symbolic_analysis)),
+                                rocsparse_status_invalid_value);
+
+        //
         // Expect an invalid status when calling symbolic_compute after compute
         //
         EXPECT_ROCSPARSE_STATUS(rocsparse_spgeam(PARAMS(rocsparse_spgeam_stage_symbolic_compute)),
@@ -725,6 +767,12 @@ static void testing_spgeam_csr_extra_wrong_stages(const Arguments& arg)
         // Expect an invalid status when calling numeric_compute after compute
         //
         EXPECT_ROCSPARSE_STATUS(rocsparse_spgeam(PARAMS(rocsparse_spgeam_stage_numeric_compute)),
+                                rocsparse_status_invalid_value);
+
+        //
+        // Expect an invalid status when calling numeric_analysis after compute
+        //
+        EXPECT_ROCSPARSE_STATUS(rocsparse_spgeam(PARAMS(rocsparse_spgeam_stage_numeric_analysis)),
                                 rocsparse_status_invalid_value);
 
         ROCSPARSE_DEBUG_VERBOSE_ON;

--- a/clients/testings/testing_spgeam_csr_2.cpp
+++ b/clients/testings/testing_spgeam_csr_2.cpp
@@ -199,14 +199,14 @@ void testing_spgeam_csr_2(const Arguments& arg)
         CHECK_ROCSPARSE_ERROR(rocsparse_set_pointer_mode(handle, rocsparse_pointer_mode_host));
         CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(handle,
                                                          descr,
-                                                         rocsparse_spgeam_input_scalar_A,
+                                                         rocsparse_spgeam_input_scalar_alpha,
                                                          h_alpha_ptr,
                                                          sizeof(h_alpha_ptr),
                                                          nullptr));
 
         CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(handle,
                                                          descr,
-                                                         rocsparse_spgeam_input_scalar_B,
+                                                         rocsparse_spgeam_input_scalar_beta,
                                                          h_beta_ptr,
                                                          sizeof(h_beta_ptr),
                                                          nullptr));
@@ -234,14 +234,14 @@ void testing_spgeam_csr_2(const Arguments& arg)
         CHECK_ROCSPARSE_ERROR(rocsparse_set_pointer_mode(handle, rocsparse_pointer_mode_device));
         CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(handle,
                                                          descr,
-                                                         rocsparse_spgeam_input_scalar_A,
+                                                         rocsparse_spgeam_input_scalar_alpha,
                                                          d_alpha_ptr,
                                                          sizeof(d_alpha_ptr),
                                                          nullptr));
 
         CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(handle,
                                                          descr,
-                                                         rocsparse_spgeam_input_scalar_B,
+                                                         rocsparse_spgeam_input_scalar_beta,
                                                          d_beta_ptr,
                                                          sizeof(d_beta_ptr),
                                                          nullptr));
@@ -274,14 +274,14 @@ void testing_spgeam_csr_2(const Arguments& arg)
         CHECK_ROCSPARSE_ERROR(rocsparse_set_pointer_mode(handle, rocsparse_pointer_mode_host));
         CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(handle,
                                                          descr,
-                                                         rocsparse_spgeam_input_scalar_A,
+                                                         rocsparse_spgeam_input_scalar_alpha,
                                                          h_alpha_ptr,
                                                          sizeof(h_alpha_ptr),
                                                          nullptr));
 
         CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(handle,
                                                          descr,
-                                                         rocsparse_spgeam_input_scalar_B,
+                                                         rocsparse_spgeam_input_scalar_beta,
                                                          h_beta_ptr,
                                                          sizeof(h_beta_ptr),
                                                          nullptr));

--- a/clients/testings/testing_spgeam_csr_2.cpp
+++ b/clients/testings/testing_spgeam_csr_2.cpp
@@ -43,16 +43,15 @@ void testing_spgeam_csr_2(const Arguments& arg)
     T h_alpha = arg.get_alpha<T>();
     T h_beta  = arg.get_beta<T>();
 
-    // -99 means nullptr
-    T* h_alpha_ptr = (h_alpha == (T)-99) ? nullptr : &h_alpha;
-    T* h_beta_ptr  = (h_beta == (T)-99) ? nullptr : &h_beta;
+    T* h_alpha_ptr = &h_alpha;
+    T* h_beta_ptr  = &h_beta;
 
     device_vector<T> d_alpha(1);
     device_vector<T> d_beta(1);
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
-    T* d_alpha_ptr = (h_alpha == (T)-99) ? nullptr : d_alpha;
-    T* d_beta_ptr  = (h_beta == (T)-99) ? nullptr : d_beta;
+    T* d_alpha_ptr = d_alpha;
+    T* d_beta_ptr  = d_beta;
 
     // Index and data type
     rocsparse_datatype ttype = get_datatype<T>();
@@ -121,11 +120,10 @@ void testing_spgeam_csr_2(const Arguments& arg)
 
     CHECK_HIP_ERROR(rocsparse_hipMalloc(&buffer, buffer_size_in_bytes));
     CHECK_ROCSPARSE_ERROR(rocsparse_set_pointer_mode(handle, rocsparse_pointer_mode_host));
+
     CHECK_ROCSPARSE_ERROR(rocsparse_spgeam(handle,
                                            descr,
-                                           h_alpha_ptr,
                                            mat_A,
-                                           h_beta_ptr,
                                            mat_B,
                                            mat_C,
                                            rocsparse_spgeam_stage_analysis,
@@ -199,13 +197,25 @@ void testing_spgeam_csr_2(const Arguments& arg)
 
         // Compute C on host multiple times.
         CHECK_ROCSPARSE_ERROR(rocsparse_set_pointer_mode(handle, rocsparse_pointer_mode_host));
+        CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(handle,
+                                                         descr,
+                                                         rocsparse_spgeam_input_scalar_A,
+                                                         h_alpha_ptr,
+                                                         sizeof(h_alpha_ptr),
+                                                         nullptr));
+
+        CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(handle,
+                                                         descr,
+                                                         rocsparse_spgeam_input_scalar_B,
+                                                         h_beta_ptr,
+                                                         sizeof(h_beta_ptr),
+                                                         nullptr));
+
         for(int i = 0; i < 2; i++)
         {
             CHECK_ROCSPARSE_ERROR(rocsparse_spgeam(handle,
                                                    descr,
-                                                   h_alpha_ptr,
                                                    mat_A,
-                                                   h_beta_ptr,
                                                    mat_B,
                                                    mat_C,
                                                    rocsparse_spgeam_stage_compute,
@@ -222,13 +232,25 @@ void testing_spgeam_csr_2(const Arguments& arg)
 
         // Compute C on device multiple times.
         CHECK_ROCSPARSE_ERROR(rocsparse_set_pointer_mode(handle, rocsparse_pointer_mode_device));
+        CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(handle,
+                                                         descr,
+                                                         rocsparse_spgeam_input_scalar_A,
+                                                         d_alpha_ptr,
+                                                         sizeof(d_alpha_ptr),
+                                                         nullptr));
+
+        CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(handle,
+                                                         descr,
+                                                         rocsparse_spgeam_input_scalar_B,
+                                                         d_beta_ptr,
+                                                         sizeof(d_beta_ptr),
+                                                         nullptr));
+
         for(int i = 0; i < 2; i++)
         {
             CHECK_ROCSPARSE_ERROR(rocsparse_spgeam(handle,
                                                    descr,
-                                                   d_alpha_ptr,
                                                    mat_A,
-                                                   d_beta_ptr,
                                                    mat_B,
                                                    mat_C,
                                                    rocsparse_spgeam_stage_compute,
@@ -250,15 +272,26 @@ void testing_spgeam_csr_2(const Arguments& arg)
         int number_hot_calls  = arg.iters;
 
         CHECK_ROCSPARSE_ERROR(rocsparse_set_pointer_mode(handle, rocsparse_pointer_mode_host));
+        CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(handle,
+                                                         descr,
+                                                         rocsparse_spgeam_input_scalar_A,
+                                                         h_alpha_ptr,
+                                                         sizeof(h_alpha_ptr),
+                                                         nullptr));
+
+        CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(handle,
+                                                         descr,
+                                                         rocsparse_spgeam_input_scalar_B,
+                                                         h_beta_ptr,
+                                                         sizeof(h_beta_ptr),
+                                                         nullptr));
 
         // Warm up
         for(int iter = 0; iter < number_cold_calls; ++iter)
         {
             CHECK_ROCSPARSE_ERROR(rocsparse_spgeam(handle,
                                                    descr,
-                                                   h_alpha_ptr,
                                                    mat_A,
-                                                   h_beta_ptr,
                                                    mat_B,
                                                    mat_C,
                                                    rocsparse_spgeam_stage_compute,
@@ -274,9 +307,7 @@ void testing_spgeam_csr_2(const Arguments& arg)
         {
             CHECK_ROCSPARSE_ERROR(rocsparse_spgeam(handle,
                                                    descr,
-                                                   h_alpha_ptr,
                                                    mat_A,
-                                                   h_beta_ptr,
                                                    mat_B,
                                                    mat_C,
                                                    rocsparse_spgeam_stage_compute,

--- a/clients/testings/testing_spgeam_reuse_csr.cpp
+++ b/clients/testings/testing_spgeam_reuse_csr.cpp
@@ -403,14 +403,14 @@ void testing_spgeam_reuse_csr(const Arguments& arg)
         CHECK_ROCSPARSE_ERROR(rocsparse_set_pointer_mode(handle, rocsparse_pointer_mode_host));
         CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(handle,
                                                          descr,
-                                                         rocsparse_spgeam_input_scalar_A,
+                                                         rocsparse_spgeam_input_scalar_alpha,
                                                          h_alpha_ptr,
                                                          sizeof(h_alpha_ptr),
                                                          nullptr));
 
         CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(handle,
                                                          descr,
-                                                         rocsparse_spgeam_input_scalar_B,
+                                                         rocsparse_spgeam_input_scalar_beta,
                                                          h_beta_ptr,
                                                          sizeof(h_beta_ptr),
                                                          nullptr));
@@ -439,14 +439,14 @@ void testing_spgeam_reuse_csr(const Arguments& arg)
         CHECK_ROCSPARSE_ERROR(rocsparse_set_pointer_mode(handle, rocsparse_pointer_mode_device));
         CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(handle,
                                                          descr,
-                                                         rocsparse_spgeam_input_scalar_A,
+                                                         rocsparse_spgeam_input_scalar_alpha,
                                                          d_alpha_ptr,
                                                          sizeof(d_alpha_ptr),
                                                          nullptr));
 
         CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(handle,
                                                          descr,
-                                                         rocsparse_spgeam_input_scalar_B,
+                                                         rocsparse_spgeam_input_scalar_beta,
                                                          d_beta_ptr,
                                                          sizeof(d_beta_ptr),
                                                          nullptr));
@@ -480,14 +480,14 @@ void testing_spgeam_reuse_csr(const Arguments& arg)
         CHECK_ROCSPARSE_ERROR(rocsparse_set_pointer_mode(handle, rocsparse_pointer_mode_host));
         CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(handle,
                                                          descr,
-                                                         rocsparse_spgeam_input_scalar_A,
+                                                         rocsparse_spgeam_input_scalar_alpha,
                                                          h_alpha_ptr,
                                                          sizeof(h_alpha_ptr),
                                                          nullptr));
 
         CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(handle,
                                                          descr,
-                                                         rocsparse_spgeam_input_scalar_B,
+                                                         rocsparse_spgeam_input_scalar_beta,
                                                          h_beta_ptr,
                                                          sizeof(d_beta_ptr),
                                                          nullptr));
@@ -650,10 +650,10 @@ static void testing_spgeam_reuse_csr_extra_wrong_stages(const Arguments& arg)
         handle, descr, rocsparse_spgeam_input_compute_datatype, &ttype, sizeof(ttype), nullptr));
 
     CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(
-        handle, descr, rocsparse_spgeam_input_scalar_A, &h_alpha, sizeof(&h_alpha), nullptr));
+        handle, descr, rocsparse_spgeam_input_scalar_alpha, &h_alpha, sizeof(&h_alpha), nullptr));
 
     CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(
-        handle, descr, rocsparse_spgeam_input_scalar_B, &h_beta, sizeof(&h_beta), nullptr));
+        handle, descr, rocsparse_spgeam_input_scalar_beta, &h_beta, sizeof(&h_beta), nullptr));
 
     // Calculate NNZ phase
     const size_t              buffer_size_in_bytes = 64;

--- a/clients/testings/testing_spgeam_reuse_csr.cpp
+++ b/clients/testings/testing_spgeam_reuse_csr.cpp
@@ -69,22 +69,19 @@ void testing_spgeam_reuse_csr_bad_arg(const Arguments& arg)
     rocsparse_spmat_descr mat_B = local_B;
     rocsparse_spmat_descr mat_C = local_C;
 
-    const T* alpha = (const T*)0x4;
-    const T* beta  = (const T*)0x4;
-
     size_t buffer_size = 0;
     void*  temp_buffer = nullptr;
 
     int32_t       nargs_to_exclude_buffer_size   = 3;
     const int32_t args_to_exclude_buffer_size[3] = {4, 6, 7};
 
-    int32_t       nargs_to_exclude_analysis   = 6;
-    const int32_t args_to_exclude_analysis[6] = {2, 4, 6, 8, 9, 10};
+    int32_t       nargs_to_exclude_analysis   = 4;
+    const int32_t args_to_exclude_analysis[4] = {4, 6, 7, 8};
 
-    int32_t       nargs_to_exclude   = 5;
-    const int32_t args_to_exclude[5] = {2, 4, 8, 9, 10};
+    int32_t       nargs_to_exclude   = 3;
+    const int32_t args_to_exclude[3] = {6, 7, 8};
 
-    rocsparse_spgeam_stage stage = rocsparse_spgeam_stage_analysis;
+    rocsparse_spgeam_stage stage = rocsparse_spgeam_stage_symbolic_analysis;
     rocsparse_error*       p_error{};
     // Analysis
     select_bad_arg_analysis(rocsparse_spgeam_buffer_size,
@@ -104,9 +101,7 @@ void testing_spgeam_reuse_csr_bad_arg(const Arguments& arg)
                             args_to_exclude_analysis,
                             handle,
                             descr,
-                            alpha,
                             mat_A,
-                            beta,
                             mat_B,
                             mat_C,
                             stage,
@@ -134,9 +129,7 @@ void testing_spgeam_reuse_csr_bad_arg(const Arguments& arg)
                             args_to_exclude,
                             handle,
                             descr,
-                            alpha,
                             mat_A,
-                            beta,
                             mat_B,
                             mat_C,
                             stage,
@@ -144,9 +137,36 @@ void testing_spgeam_reuse_csr_bad_arg(const Arguments& arg)
                             temp_buffer,
                             p_error);
 
-    stage = rocsparse_spgeam_stage_numeric_compute;
+    // Numeric analysis
+    stage = rocsparse_spgeam_stage_numeric_analysis;
 
-    // Numeric
+    select_bad_arg_analysis(rocsparse_spgeam_buffer_size,
+                            nargs_to_exclude_buffer_size,
+                            args_to_exclude_buffer_size,
+                            handle,
+                            descr,
+                            mat_A,
+                            mat_B,
+                            mat_C,
+                            stage,
+                            &buffer_size,
+                            p_error);
+
+    select_bad_arg_analysis(rocsparse_spgeam,
+                            nargs_to_exclude_analysis,
+                            args_to_exclude_analysis,
+                            handle,
+                            descr,
+                            mat_A,
+                            mat_B,
+                            mat_C,
+                            stage,
+                            buffer_size,
+                            temp_buffer,
+                            p_error);
+
+    // Numeric compute
+    stage = rocsparse_spgeam_stage_numeric_compute;
     select_bad_arg_analysis(rocsparse_spgeam_buffer_size,
                             nargs_to_exclude_buffer_size,
                             args_to_exclude_buffer_size,
@@ -164,9 +184,7 @@ void testing_spgeam_reuse_csr_bad_arg(const Arguments& arg)
                             args_to_exclude,
                             handle,
                             descr,
-                            alpha,
                             mat_A,
-                            beta,
                             mat_B,
                             mat_C,
                             stage,
@@ -190,16 +208,15 @@ void testing_spgeam_reuse_csr(const Arguments& arg)
     T h_alpha = arg.get_alpha<T>();
     T h_beta  = arg.get_beta<T>();
 
-    // -99 means nullptr
-    T* h_alpha_ptr = (h_alpha == (T)-99) ? nullptr : &h_alpha;
-    T* h_beta_ptr  = (h_beta == (T)-99) ? nullptr : &h_beta;
+    T* h_alpha_ptr = &h_alpha;
+    T* h_beta_ptr  = &h_beta;
 
     device_vector<T> d_alpha(1);
     device_vector<T> d_beta(1);
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
-    T* d_alpha_ptr = (h_alpha == (T)-99) ? nullptr : d_alpha;
-    T* d_beta_ptr  = (h_beta == (T)-99) ? nullptr : d_beta;
+    T* d_alpha_ptr = d_alpha;
+    T* d_beta_ptr  = d_beta;
 
     // Index and data type
     rocsparse_datatype ttype = get_datatype<T>();
@@ -259,7 +276,7 @@ void testing_spgeam_reuse_csr(const Arguments& arg)
                                                        mat_A,
                                                        mat_B,
                                                        nullptr,
-                                                       rocsparse_spgeam_stage_analysis,
+                                                       rocsparse_spgeam_stage_symbolic_analysis,
                                                        &buffer_size_in_bytes,
                                                        nullptr));
 
@@ -268,12 +285,10 @@ void testing_spgeam_reuse_csr(const Arguments& arg)
     CHECK_ROCSPARSE_ERROR(rocsparse_set_pointer_mode(handle, rocsparse_pointer_mode_host));
     CHECK_ROCSPARSE_ERROR(rocsparse_spgeam(handle,
                                            descr,
-                                           h_alpha_ptr,
                                            mat_A,
-                                           h_beta_ptr,
                                            mat_B,
                                            nullptr,
-                                           rocsparse_spgeam_stage_analysis,
+                                           rocsparse_spgeam_stage_symbolic_analysis,
                                            buffer_size_in_bytes,
                                            buffer,
                                            nullptr));
@@ -301,11 +316,10 @@ void testing_spgeam_reuse_csr(const Arguments& arg)
                                                        &buffer_size_in_bytes,
                                                        nullptr));
     CHECK_HIP_ERROR(rocsparse_hipMalloc(&buffer, buffer_size_in_bytes));
+
     CHECK_ROCSPARSE_ERROR(rocsparse_spgeam(handle,
                                            descr,
-                                           d_alpha_ptr,
                                            mat_A,
-                                           d_beta_ptr,
                                            mat_B,
                                            mat_C,
                                            rocsparse_spgeam_stage_symbolic_compute,
@@ -315,6 +329,27 @@ void testing_spgeam_reuse_csr(const Arguments& arg)
     CHECK_HIP_ERROR(rocsparse_hipFree(buffer));
 
     // Numeric compute phase
+    CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_buffer_size(handle,
+                                                       descr,
+                                                       mat_A,
+                                                       mat_B,
+                                                       mat_C,
+                                                       rocsparse_spgeam_stage_numeric_analysis,
+                                                       &buffer_size_in_bytes,
+                                                       nullptr));
+
+    CHECK_HIP_ERROR(rocsparse_hipMalloc(&buffer, buffer_size_in_bytes));
+    CHECK_ROCSPARSE_ERROR(rocsparse_spgeam(handle,
+                                           descr,
+                                           mat_A,
+                                           mat_B,
+                                           mat_C,
+                                           rocsparse_spgeam_stage_numeric_analysis,
+                                           buffer_size_in_bytes,
+                                           buffer,
+                                           nullptr));
+    CHECK_HIP_ERROR(rocsparse_hipFree(buffer));
+
     CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_buffer_size(handle,
                                                        descr,
                                                        mat_A,
@@ -366,13 +401,25 @@ void testing_spgeam_reuse_csr(const Arguments& arg)
 
         // Compute C on host multiple times.
         CHECK_ROCSPARSE_ERROR(rocsparse_set_pointer_mode(handle, rocsparse_pointer_mode_host));
+        CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(handle,
+                                                         descr,
+                                                         rocsparse_spgeam_input_scalar_A,
+                                                         h_alpha_ptr,
+                                                         sizeof(h_alpha_ptr),
+                                                         nullptr));
+
+        CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(handle,
+                                                         descr,
+                                                         rocsparse_spgeam_input_scalar_B,
+                                                         h_beta_ptr,
+                                                         sizeof(h_beta_ptr),
+                                                         nullptr));
+
         for(int32_t i = 0; i < 2; i++)
         {
             CHECK_ROCSPARSE_ERROR(rocsparse_spgeam(handle,
                                                    descr,
-                                                   h_alpha_ptr,
                                                    mat_A,
-                                                   h_beta_ptr,
                                                    mat_B,
                                                    mat_C,
                                                    rocsparse_spgeam_stage_numeric_compute,
@@ -390,13 +437,25 @@ void testing_spgeam_reuse_csr(const Arguments& arg)
 
         // Compute C on device multiple times.
         CHECK_ROCSPARSE_ERROR(rocsparse_set_pointer_mode(handle, rocsparse_pointer_mode_device));
+        CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(handle,
+                                                         descr,
+                                                         rocsparse_spgeam_input_scalar_A,
+                                                         d_alpha_ptr,
+                                                         sizeof(d_alpha_ptr),
+                                                         nullptr));
+
+        CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(handle,
+                                                         descr,
+                                                         rocsparse_spgeam_input_scalar_B,
+                                                         d_beta_ptr,
+                                                         sizeof(d_beta_ptr),
+                                                         nullptr));
+
         for(int32_t i = 0; i < 2; i++)
         {
             CHECK_ROCSPARSE_ERROR(rocsparse_spgeam(handle,
                                                    descr,
-                                                   d_alpha_ptr,
                                                    mat_A,
-                                                   d_beta_ptr,
                                                    mat_B,
                                                    mat_C,
                                                    rocsparse_spgeam_stage_numeric_compute,
@@ -419,15 +478,26 @@ void testing_spgeam_reuse_csr(const Arguments& arg)
         int32_t number_hot_calls  = arg.iters;
 
         CHECK_ROCSPARSE_ERROR(rocsparse_set_pointer_mode(handle, rocsparse_pointer_mode_host));
+        CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(handle,
+                                                         descr,
+                                                         rocsparse_spgeam_input_scalar_A,
+                                                         h_alpha_ptr,
+                                                         sizeof(h_alpha_ptr),
+                                                         nullptr));
+
+        CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(handle,
+                                                         descr,
+                                                         rocsparse_spgeam_input_scalar_B,
+                                                         h_beta_ptr,
+                                                         sizeof(d_beta_ptr),
+                                                         nullptr));
 
         // Warm up
         for(int32_t iter = 0; iter < number_cold_calls; ++iter)
         {
             CHECK_ROCSPARSE_ERROR(rocsparse_spgeam(handle,
                                                    descr,
-                                                   h_alpha_ptr,
                                                    mat_A,
-                                                   h_beta_ptr,
                                                    mat_B,
                                                    mat_C,
                                                    rocsparse_spgeam_stage_numeric_compute,
@@ -443,9 +513,7 @@ void testing_spgeam_reuse_csr(const Arguments& arg)
         {
             CHECK_ROCSPARSE_ERROR(rocsparse_spgeam(handle,
                                                    descr,
-                                                   h_alpha_ptr,
                                                    mat_A,
-                                                   h_beta_ptr,
                                                    mat_B,
                                                    mat_C,
                                                    rocsparse_spgeam_stage_numeric_compute,
@@ -581,17 +649,22 @@ static void testing_spgeam_reuse_csr_extra_wrong_stages(const Arguments& arg)
     CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(
         handle, descr, rocsparse_spgeam_input_compute_datatype, &ttype, sizeof(ttype), nullptr));
 
+    CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(
+        handle, descr, rocsparse_spgeam_input_scalar_A, &h_alpha, sizeof(&h_alpha), nullptr));
+
+    CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(
+        handle, descr, rocsparse_spgeam_input_scalar_B, &h_beta, sizeof(&h_beta), nullptr));
+
     // Calculate NNZ phase
     const size_t              buffer_size_in_bytes = 64;
     device_dense_vector<char> buffer(buffer_size_in_bytes);
 
-#define PARAMS(stage) \
-    handle, descr, &h_alpha, A, &h_beta, B, C, stage, buffer_size_in_bytes, buffer, nullptr
+#define PARAMS(stage) handle, descr, A, B, C, stage, buffer_size_in_bytes, buffer, nullptr
 
     {
         ROCSPARSE_DEBUG_VERBOSE_OFF;
         //
-        // Expect an invalid status when calling symbolic_compute before analysis
+        // Expect an invalid status when calling symbolic_compute before symbolic analysis
         //
         EXPECT_ROCSPARSE_STATUS(rocsparse_spgeam(PARAMS(rocsparse_spgeam_stage_symbolic_compute)),
                                 rocsparse_status_invalid_value);
@@ -599,16 +672,16 @@ static void testing_spgeam_reuse_csr_extra_wrong_stages(const Arguments& arg)
     }
 
     //
-    // Call analysis
+    // Call symbolic analysis
     //
-    CHECK_ROCSPARSE_ERROR(rocsparse_spgeam(PARAMS(rocsparse_spgeam_stage_analysis)));
+    CHECK_ROCSPARSE_ERROR(rocsparse_spgeam(PARAMS(rocsparse_spgeam_stage_symbolic_analysis)));
 
     {
         ROCSPARSE_DEBUG_VERBOSE_OFF;
         //
-        // Expect an invalid status when calling analysis twice
+        // Expect an invalid status when calling symbolic analysis twice
         //
-        EXPECT_ROCSPARSE_STATUS(rocsparse_spgeam(PARAMS(rocsparse_spgeam_stage_analysis)),
+        EXPECT_ROCSPARSE_STATUS(rocsparse_spgeam(PARAMS(rocsparse_spgeam_stage_symbolic_analysis)),
                                 rocsparse_status_invalid_value);
 
         ROCSPARSE_DEBUG_VERBOSE_ON;
@@ -631,6 +704,32 @@ static void testing_spgeam_reuse_csr_extra_wrong_stages(const Arguments& arg)
         // Expect an invalid status when calling compute after symbolic_compute
         //
         EXPECT_ROCSPARSE_STATUS(rocsparse_spgeam(PARAMS(rocsparse_spgeam_stage_compute)),
+                                rocsparse_status_invalid_value);
+
+        ROCSPARSE_DEBUG_VERBOSE_ON;
+    }
+
+    {
+        ROCSPARSE_DEBUG_VERBOSE_OFF;
+        //
+        // Expect an invalid status when calling numeric_compute before numeric_analysis
+        //
+        EXPECT_ROCSPARSE_STATUS(rocsparse_spgeam(PARAMS(rocsparse_spgeam_stage_symbolic_compute)),
+                                rocsparse_status_invalid_value);
+        ROCSPARSE_DEBUG_VERBOSE_ON;
+    }
+
+    //
+    // Call numeric analysis
+    //
+    CHECK_ROCSPARSE_ERROR(rocsparse_spgeam(PARAMS(rocsparse_spgeam_stage_numeric_analysis)));
+
+    {
+        ROCSPARSE_DEBUG_VERBOSE_OFF;
+        //
+        // Expect an invalid status when calling numeric analysis twice
+        //
+        EXPECT_ROCSPARSE_STATUS(rocsparse_spgeam(PARAMS(rocsparse_spgeam_stage_numeric_analysis)),
                                 rocsparse_status_invalid_value);
 
         ROCSPARSE_DEBUG_VERBOSE_ON;

--- a/clients/testings/testing_spgeam_reuse_csr_2.cpp
+++ b/clients/testings/testing_spgeam_reuse_csr_2.cpp
@@ -43,16 +43,15 @@ void testing_spgeam_reuse_csr_2(const Arguments& arg)
     T h_alpha = arg.get_alpha<T>();
     T h_beta  = arg.get_beta<T>();
 
-    // -99 means nullptr
-    T* h_alpha_ptr = (h_alpha == (T)-99) ? nullptr : &h_alpha;
-    T* h_beta_ptr  = (h_beta == (T)-99) ? nullptr : &h_beta;
+    T* h_alpha_ptr = &h_alpha;
+    T* h_beta_ptr  = &h_beta;
 
     device_vector<T> d_alpha(1);
     device_vector<T> d_beta(1);
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
-    T* d_alpha_ptr = (h_alpha == (T)-99) ? nullptr : d_alpha;
-    T* d_beta_ptr  = (h_beta == (T)-99) ? nullptr : d_beta;
+    T* d_alpha_ptr = d_alpha;
+    T* d_beta_ptr  = d_beta;
 
     // Index and data type
     rocsparse_datatype ttype = get_datatype<T>();
@@ -115,7 +114,7 @@ void testing_spgeam_reuse_csr_2(const Arguments& arg)
                                                        mat_A,
                                                        mat_B,
                                                        mat_C,
-                                                       rocsparse_spgeam_stage_analysis,
+                                                       rocsparse_spgeam_stage_symbolic_analysis,
                                                        &buffer_size_in_bytes,
                                                        nullptr));
 
@@ -124,12 +123,10 @@ void testing_spgeam_reuse_csr_2(const Arguments& arg)
     CHECK_ROCSPARSE_ERROR(rocsparse_set_pointer_mode(handle, rocsparse_pointer_mode_host));
     CHECK_ROCSPARSE_ERROR(rocsparse_spgeam(handle,
                                            descr,
-                                           h_alpha_ptr,
                                            mat_A,
-                                           h_beta_ptr,
                                            mat_B,
                                            mat_C,
-                                           rocsparse_spgeam_stage_analysis,
+                                           rocsparse_spgeam_stage_symbolic_analysis,
                                            buffer_size_in_bytes,
                                            buffer,
                                            nullptr));
@@ -159,9 +156,7 @@ void testing_spgeam_reuse_csr_2(const Arguments& arg)
     CHECK_HIP_ERROR(rocsparse_hipMalloc(&buffer, buffer_size_in_bytes));
     CHECK_ROCSPARSE_ERROR(rocsparse_spgeam(handle,
                                            descr,
-                                           h_alpha_ptr,
                                            mat_A,
-                                           h_beta_ptr,
                                            mat_B,
                                            mat_C,
                                            rocsparse_spgeam_stage_symbolic_compute,
@@ -171,6 +166,28 @@ void testing_spgeam_reuse_csr_2(const Arguments& arg)
     CHECK_HIP_ERROR(rocsparse_hipFree(buffer));
 
     // Numeric compute phase
+
+    CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_buffer_size(handle,
+                                                       descr,
+                                                       mat_A,
+                                                       mat_B,
+                                                       mat_C,
+                                                       rocsparse_spgeam_stage_numeric_analysis,
+                                                       &buffer_size_in_bytes,
+                                                       nullptr));
+
+    CHECK_HIP_ERROR(rocsparse_hipMalloc(&buffer, buffer_size_in_bytes));
+    CHECK_ROCSPARSE_ERROR(rocsparse_spgeam(handle,
+                                           descr,
+                                           mat_A,
+                                           mat_B,
+                                           mat_C,
+                                           rocsparse_spgeam_stage_numeric_analysis,
+                                           buffer_size_in_bytes,
+                                           buffer,
+                                           nullptr));
+    CHECK_HIP_ERROR(rocsparse_hipFree(buffer));
+
     CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_buffer_size(handle,
                                                        descr,
                                                        mat_A,
@@ -222,13 +239,26 @@ void testing_spgeam_reuse_csr_2(const Arguments& arg)
 
         // Compute C on host multiple times.
         CHECK_ROCSPARSE_ERROR(rocsparse_set_pointer_mode(handle, rocsparse_pointer_mode_host));
+
+        CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(handle,
+                                                         descr,
+                                                         rocsparse_spgeam_input_scalar_A,
+                                                         h_alpha_ptr,
+                                                         sizeof(h_alpha_ptr),
+                                                         nullptr));
+
+        CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(handle,
+                                                         descr,
+                                                         rocsparse_spgeam_input_scalar_B,
+                                                         h_beta_ptr,
+                                                         sizeof(h_beta_ptr),
+                                                         nullptr));
+
         for(int i = 0; i < 2; i++)
         {
             CHECK_ROCSPARSE_ERROR(rocsparse_spgeam(handle,
                                                    descr,
-                                                   h_alpha_ptr,
                                                    mat_A,
-                                                   h_beta_ptr,
                                                    mat_B,
                                                    mat_C,
                                                    rocsparse_spgeam_stage_numeric_compute,
@@ -246,13 +276,26 @@ void testing_spgeam_reuse_csr_2(const Arguments& arg)
 
         // Compute C on device multiple times.
         CHECK_ROCSPARSE_ERROR(rocsparse_set_pointer_mode(handle, rocsparse_pointer_mode_device));
+
+        CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(handle,
+                                                         descr,
+                                                         rocsparse_spgeam_input_scalar_A,
+                                                         d_alpha_ptr,
+                                                         sizeof(d_alpha_ptr),
+                                                         nullptr));
+
+        CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(handle,
+                                                         descr,
+                                                         rocsparse_spgeam_input_scalar_B,
+                                                         d_beta_ptr,
+                                                         sizeof(d_beta_ptr),
+                                                         nullptr));
+
         for(int i = 0; i < 2; i++)
         {
             CHECK_ROCSPARSE_ERROR(rocsparse_spgeam(handle,
                                                    descr,
-                                                   d_alpha_ptr,
                                                    mat_A,
-                                                   d_beta_ptr,
                                                    mat_B,
                                                    mat_C,
                                                    rocsparse_spgeam_stage_numeric_compute,
@@ -276,14 +319,26 @@ void testing_spgeam_reuse_csr_2(const Arguments& arg)
 
         CHECK_ROCSPARSE_ERROR(rocsparse_set_pointer_mode(handle, rocsparse_pointer_mode_host));
 
+        CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(handle,
+                                                         descr,
+                                                         rocsparse_spgeam_input_scalar_A,
+                                                         h_alpha_ptr,
+                                                         sizeof(h_alpha_ptr),
+                                                         nullptr));
+
+        CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(handle,
+                                                         descr,
+                                                         rocsparse_spgeam_input_scalar_B,
+                                                         h_beta_ptr,
+                                                         sizeof(h_beta_ptr),
+                                                         nullptr));
+
         // Warm up
         for(int iter = 0; iter < number_cold_calls; ++iter)
         {
             CHECK_ROCSPARSE_ERROR(rocsparse_spgeam(handle,
                                                    descr,
-                                                   h_alpha_ptr,
                                                    mat_A,
-                                                   h_beta_ptr,
                                                    mat_B,
                                                    mat_C,
                                                    rocsparse_spgeam_stage_numeric_compute,
@@ -299,9 +354,7 @@ void testing_spgeam_reuse_csr_2(const Arguments& arg)
         {
             CHECK_ROCSPARSE_ERROR(rocsparse_spgeam(handle,
                                                    descr,
-                                                   h_alpha_ptr,
                                                    mat_A,
-                                                   h_beta_ptr,
                                                    mat_B,
                                                    mat_C,
                                                    rocsparse_spgeam_stage_numeric_compute,

--- a/clients/testings/testing_spgeam_reuse_csr_2.cpp
+++ b/clients/testings/testing_spgeam_reuse_csr_2.cpp
@@ -242,14 +242,14 @@ void testing_spgeam_reuse_csr_2(const Arguments& arg)
 
         CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(handle,
                                                          descr,
-                                                         rocsparse_spgeam_input_scalar_A,
+                                                         rocsparse_spgeam_input_scalar_alpha,
                                                          h_alpha_ptr,
                                                          sizeof(h_alpha_ptr),
                                                          nullptr));
 
         CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(handle,
                                                          descr,
-                                                         rocsparse_spgeam_input_scalar_B,
+                                                         rocsparse_spgeam_input_scalar_beta,
                                                          h_beta_ptr,
                                                          sizeof(h_beta_ptr),
                                                          nullptr));
@@ -279,14 +279,14 @@ void testing_spgeam_reuse_csr_2(const Arguments& arg)
 
         CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(handle,
                                                          descr,
-                                                         rocsparse_spgeam_input_scalar_A,
+                                                         rocsparse_spgeam_input_scalar_alpha,
                                                          d_alpha_ptr,
                                                          sizeof(d_alpha_ptr),
                                                          nullptr));
 
         CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(handle,
                                                          descr,
-                                                         rocsparse_spgeam_input_scalar_B,
+                                                         rocsparse_spgeam_input_scalar_beta,
                                                          d_beta_ptr,
                                                          sizeof(d_beta_ptr),
                                                          nullptr));
@@ -321,14 +321,14 @@ void testing_spgeam_reuse_csr_2(const Arguments& arg)
 
         CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(handle,
                                                          descr,
-                                                         rocsparse_spgeam_input_scalar_A,
+                                                         rocsparse_spgeam_input_scalar_alpha,
                                                          h_alpha_ptr,
                                                          sizeof(h_alpha_ptr),
                                                          nullptr));
 
         CHECK_ROCSPARSE_ERROR(rocsparse_spgeam_set_input(handle,
                                                          descr,
-                                                         rocsparse_spgeam_input_scalar_B,
+                                                         rocsparse_spgeam_input_scalar_beta,
                                                          h_beta_ptr,
                                                          sizeof(h_beta_ptr),
                                                          nullptr));

--- a/clients/tests/test_spgeam_csr.yaml
+++ b/clients/tests/test_spgeam_csr.yaml
@@ -32,8 +32,8 @@ Definitions:
     - { alpha:   0.0, beta:   1.0, alphai:  0.0, betai: 1.0 }
 
   - &alpha_beta_range_checkin
-    - { alpha: -99.0, beta:   1.5, alphai:  0.0, betai: 0.3 }
-    - { alpha:   2.0, beta: -99.0, alphai:  0.5, betai: 0.3 }
+    - { alpha: 0.0, beta:   1.5, alphai:  0.0, betai: 0.3 }
+    - { alpha:   2.0, beta: 0.0, alphai:  0.5, betai: 0.3 }
     - { alpha:   3.0, beta:   1.7, alphai: -0.5, betai: 0.8 }
 
   - &alpha_beta_range_nightly

--- a/clients/tests/test_spgeam_csr_2.yaml
+++ b/clients/tests/test_spgeam_csr_2.yaml
@@ -32,8 +32,8 @@ Definitions:
     - { alpha:   0.0, beta:   1.0, alphai:  0.0, betai: 1.0 }
 
   - &alpha_beta_range_checkin
-    - { alpha: -99.0, beta:   1.5, alphai:  0.0, betai: 0.3 }
-    - { alpha:   2.0, beta: -99.0, alphai:  0.5, betai: 0.3 }
+    - { alpha: 0.0, beta:   1.5, alphai:  0.0, betai: 0.3 }
+    - { alpha:   2.0, beta: 0.0, alphai:  0.5, betai: 0.3 }
     - { alpha:   3.0, beta:   1.7, alphai: -0.5, betai: 0.8 }
 
   - &alpha_beta_range_nightly

--- a/clients/tests/test_spgeam_reuse_csr.yaml
+++ b/clients/tests/test_spgeam_reuse_csr.yaml
@@ -32,8 +32,8 @@ Definitions:
     - { alpha:   0.0, beta:   1.0, alphai:  0.0, betai: 1.0 }
 
   - &alpha_beta_range_checkin
-    - { alpha: -99.0, beta:   1.5, alphai:  0.0, betai: 0.3 }
-    - { alpha:   2.0, beta: -99.0, alphai:  0.5, betai: 0.3 }
+    - { alpha: 0.0, beta:   1.5, alphai:  0.0, betai: 0.3 }
+    - { alpha:   2.0, beta: 0.0, alphai:  0.5, betai: 0.3 }
     - { alpha:   3.0, beta:   1.7, alphai: -0.5, betai: 0.8 }
 
   - &alpha_beta_range_nightly

--- a/clients/tests/test_spgeam_reuse_csr_2.yaml
+++ b/clients/tests/test_spgeam_reuse_csr_2.yaml
@@ -32,8 +32,8 @@ Definitions:
     - { alpha:   1.0, beta:   0.0, alphai:  0.0, betai: 1.0 }
 
   - &alpha_beta_range_checkin
-    - { alpha: -99.0, beta:   1.5, alphai:  0.0, betai: 0.3 }
-    - { alpha:   2.0, beta: -99.0, alphai:  0.5, betai: 0.3 }
+    - { alpha: 0.0, beta:   1.5, alphai:  0.0, betai: 0.3 }
+    - { alpha:   2.0, beta: 0.0, alphai:  0.5, betai: 0.3 }
     - { alpha:   3.0, beta:   1.7, alphai: -0.5, betai: 0.8 }
 
   - &alpha_beta_range_nightly

--- a/library/include/internal/generic/rocsparse_spgeam.h
+++ b/library/include/internal/generic/rocsparse_spgeam.h
@@ -114,7 +114,15 @@ rocsparse_status rocsparse_spgeam_buffer_size(rocsparse_handle            handle
 *  \p rocsparse_spgeam. Once the computation is complete and the SpGEAM descriptor is no longer needed, the user must call
 *  \ref rocsparse_destroy_spgeam_descr. See full code example below.
 *
-*  The stage \ref rocsparse_spgeam_stage_compute computes the symbolic part and the numeric of the resulting matrix C. If the user wants to perform multiple operations involving matrices of same sparsity patterns but with different numerical values, then the symbolic stages (\ref rocsparse_spgeam_stage_symbolic_analysis and \ref rocsparse_spgeam_stage_symbolic_compute) and the numeric stages (\ref rocsparse_spgeam_stage_numeric_analysis and \ref rocsparse_spgeam_stage_numeric_compute) can be used to separate the symbolic calculation from the numeric calculation. Note that the stages  \ref rocsparse_spgeam_stage_analysis and \ref rocsparse_spgeam_stage_compute cannot be mixed with the stages \ref rocsparse_spgeam_stage_symbolic_analysis, \ref rocsparse_spgeam_stage_symbolic_compute, \ref rocsparse_spgeam_stage_numeric_analysis, and \ref rocsparse_spgeam_stage_numeric_compute.
+*  The stage \ref rocsparse_spgeam_stage_compute computes the symbolic part and the numeric of the resulting matrix C. If the user wants to perform multiple operations involving matrices of same sparsity patterns but with different numerical values, then the symbolic stages (\ref rocsparse_spgeam_stage_symbolic_analysis and \ref rocsparse_spgeam_stage_symbolic_compute) and the numeric stages (\ref rocsparse_spgeam_stage_numeric_analysis and \ref rocsparse_spgeam_stage_numeric_compute) can be used to separate the symbolic calculation from the numeric calculation.
+*
+*  \note The stages  \ref rocsparse_spgeam_stage_analysis and \ref rocsparse_spgeam_stage_compute cannot be mixed with the stages \ref rocsparse_spgeam_stage_symbolic_analysis, \ref rocsparse_spgeam_stage_symbolic_compute, \ref rocsparse_spgeam_stage_numeric_analysis, and \ref rocsparse_spgeam_stage_numeric_compute.
+*  \note The stage \ref rocsparse_spgeam_stage_analysis must precede the stage \ref rocsparse_spgeam_stage_compute.
+*  \note The stage \ref rocsparse_spgeam_stage_symbolic_analysis must precede the stage \ref rocsparse_spgeam_stage_symbolic_compute.
+*  \note The stage \ref rocsparse_spgeam_stage_numeric_analysis must precede the stage \ref rocsparse_spgeam_stage_numeric_compute.
+*  \note The symbolic stages are not required to perform the numeric stages.
+*  \note The stage \ref rocsparse_spgeam_stage_numeric_analysis must be re-applied if the numeric values of the input matrices \p mat_A and \p mat_B have changed between subsquent calls of the stage \ref rocsparse_spgeam_stage_numeric_compute.
+*
 *  \p rocsparse_spgeam supports multiple combinations of index types, data types, and compute types. The tables below indicate
 *  the currently supported different index and data types that can be used for the sparse matrices \f$op(A)\f$, \f$op(B)\f$, and
 *  \f$C\f$, and the compute type for \f$\alpha\f$ and \f$\beta\f$. The advantage of using different index and data types is to save on

--- a/library/include/internal/generic/rocsparse_spgeam.h
+++ b/library/include/internal/generic/rocsparse_spgeam.h
@@ -330,8 +330,8 @@ rocsparse_status rocsparse_spgeam_buffer_size(rocsparse_handle            handle
 *   rocsparse_spgeam_buffer_size(handle, descr, matA, matB, matC, rocsparse_spgeam_stage_compute, &buffer_size_in_bytes, p_error);
 *
 *   // Set alpha and beta
-*   rocsparse_spgeam_set_input(handle, descr, rocsparse_spgeam_input_scalar_A, &alpha, sizeof(alpha), p_error);
-*   rocsparse_spgeam_set_input(handle, descr, rocsparse_spgeam_input_scalar_B, &beta, sizeof(beta), p_error);
+*   rocsparse_spgeam_set_input(handle, descr, rocsparse_spgeam_input_scalar_alpha, &alpha, sizeof(alpha), p_error);
+*   rocsparse_spgeam_set_input(handle, descr, rocsparse_spgeam_input_scalar_beta, &beta, sizeof(beta), p_error);
 *
 *   hipMalloc(&buffer, buffer_size_in_bytes);
 *   rocsparse_spgeam(handle, descr, matA, matB, matC, rocsparse_spgeam_stage_compute, buffer_size_in_bytes, buffer, p_error);
@@ -466,8 +466,8 @@ rocsparse_status rocsparse_spgeam_buffer_size(rocsparse_handle            handle
 *   rocsparse_spgeam_set_input(handle, descr, rocsparse_spgeam_input_scalar_datatype, &scalar_datatype, sizeof(scalar_datatype), p_error);
 *
 *   // Set alpha and beta.
-*   rocsparse_spgeam_set_input(handle, descr, rocsparse_spgeam_input_scalar_A, &alpha, sizeof(alpha), p_error);
-*   rocsparse_spgeam_set_input(handle, descr, rocsparse_spgeam_input_scalar_B, &beta, sizeof(beta), p_error);
+*   rocsparse_spgeam_set_input(handle, descr, rocsparse_spgeam_input_scalar_alpha, &alpha, sizeof(alpha), p_error);
+*   rocsparse_spgeam_set_input(handle, descr, rocsparse_spgeam_input_scalar_beta, &beta, sizeof(beta), p_error);
 *
 *   // Set the compute type on the descriptor
 *   const rocsparse_datatype compute_datatype = rocsparse_datatype_f32_r;

--- a/library/include/internal/generic/rocsparse_spgeam.h
+++ b/library/include/internal/generic/rocsparse_spgeam.h
@@ -114,7 +114,7 @@ rocsparse_status rocsparse_spgeam_buffer_size(rocsparse_handle            handle
 *  \p rocsparse_spgeam. Once the computation is complete and the SpGEAM descriptor is no longer needed, the user must call
 *  \ref rocsparse_destroy_spgeam_descr. See full code example below.
 *
-*  The stage \ref rocsparse_spgeam_stage_compute computes the symbolic part and the numeric of the resulting matrix C. If the user wants to perform multiple operations involving matrices of same sparsity patterns but with different numerical values, then the stages \ref rocsparse_spgeam_stage_symbolic_compute and \ref rocsparse_spgeam_stage_numeric_compute can be used to separate the symbolic calculation from the numeric calculation. Note that the stage \ref rocsparse_spgeam_stage_compute cannot be mixed with the stages \ref rocsparse_spgeam_stage_symbolic_compute and \ref rocsparse_spgeam_stage_numeric_compute.
+*  The stage \ref rocsparse_spgeam_stage_compute computes the symbolic part and the numeric of the resulting matrix C. If the user wants to perform multiple operations involving matrices of same sparsity patterns but with different numerical values, then the symbolic stages (\ref rocsparse_spgeam_stage_symbolic_analysis and \ref rocsparse_spgeam_stage_symbolic_compute) and the numeric stages (\ref rocsparse_spgeam_stage_numeric_analysis and \ref rocsparse_spgeam_stage_numeric_compute) can be used to separate the symbolic calculation from the numeric calculation. Note that the stages  \ref rocsparse_spgeam_stage_analysis and \ref rocsparse_spgeam_stage_compute cannot be mixed with the stages \ref rocsparse_spgeam_stage_symbolic_analysis, \ref rocsparse_spgeam_stage_symbolic_compute, \ref rocsparse_spgeam_stage_numeric_analysis, and \ref rocsparse_spgeam_stage_numeric_compute.
 *  \p rocsparse_spgeam supports multiple combinations of index types, data types, and compute types. The tables below indicate
 *  the currently supported different index and data types that can be used for the sparse matrices \f$op(A)\f$, \f$op(B)\f$, and
 *  \f$C\f$, and the compute type for \f$\alpha\f$ and \f$\beta\f$. The advantage of using different index and data types is to save on
@@ -157,11 +157,7 @@ rocsparse_status rocsparse_spgeam_buffer_size(rocsparse_handle            handle
 *  arrays. In the scenario where \f$C\f$ requires a larger index type for the row offset array, the user would need to store all three
 *  matrices using the larger index type \ref rocsparse_datatype_f64_r for the row offsets array.
 *
-*  \note If \f$\alpha == 0\f$, then \f$C = \beta \cdot op(B)\f$ will be computed.
-*  \note If \f$\beta == 0\f$, then \f$C = \alpha \cdot op(A) \f$ will be
-*  computed.
 *  \note Currently only CSR format is supported.
-*  \note \f$\alpha == beta == 0\f$ is invalid.
 *  \note Currently, only \p trans_A == \ref rocsparse_operation_none is supported.
 *  \note Currently, only \p trans_B == \ref rocsparse_operation_none is supported.
 *
@@ -173,11 +169,7 @@ rocsparse_status rocsparse_spgeam_buffer_size(rocsparse_handle            handle
 *  @param[in]
 *  descr        SpGEAM descriptor
 *  @param[in]
-*  alpha        scalar \f$\alpha\f$.
-*  @param[in]
 *  mat_A        sparse matrix \f$A\f$ descriptor.
-*  @param[in]
-*  beta         scalar \f$\beta\f$.
 *  @param[in]
 *  mat_B        sparse matrix \f$B\f$ descriptor.
 *  @param[out]
@@ -194,8 +186,7 @@ rocsparse_status rocsparse_spgeam_buffer_size(rocsparse_handle            handle
 *
 *  \retval rocsparse_status_success the operation completed successfully.
 *  \retval rocsparse_status_invalid_handle the library context was not initialized.
-*  \retval rocsparse_status_invalid_pointer \p alpha and \p beta are invalid,
-*          \p mat_A, \p mat_B, \p mat_C, \p descr or \p buffer_size pointer is invalid.
+*  \retval rocsparse_status_invalid_pointer \p mat_A, \p mat_B, \p mat_C, \p descr or \p buffer_size pointer is invalid.
 *
 *  \par First Example
 *  \code{.c}
@@ -304,7 +295,7 @@ rocsparse_status rocsparse_spgeam_buffer_size(rocsparse_handle            handle
 *   rocsparse_spgeam_buffer_size(handle, descr, matA, matB, nullptr, rocsparse_spgeam_stage_analysis, &buffer_size_in_bytes, p_error);
 *
 *   hipMalloc(&buffer, buffer_size_in_bytes);
-*   rocsparse_spgeam(handle, descr, &alpha, matA, &beta, matB, nullptr, rocsparse_spgeam_stage_analysis, buffer_size_in_bytes, buffer, p_error);
+*   rocsparse_spgeam(handle, descr, matA, matB, nullptr, rocsparse_spgeam_stage_analysis, buffer_size_in_bytes, buffer, p_error);
 *   hipFree(buffer);
 *
 *   // Ensure analysis stage is complete before grabbing C non-zero count
@@ -330,8 +321,12 @@ rocsparse_status rocsparse_spgeam_buffer_size(rocsparse_handle            handle
 *   // Compute phase
 *   rocsparse_spgeam_buffer_size(handle, descr, matA, matB, matC, rocsparse_spgeam_stage_compute, &buffer_size_in_bytes, p_error);
 *
+*   // Set alpha and beta
+*   rocsparse_spgeam_set_input(handle, descr, rocsparse_spgeam_input_scalar_A, &alpha, sizeof(alpha), p_error);
+*   rocsparse_spgeam_set_input(handle, descr, rocsparse_spgeam_input_scalar_B, &beta, sizeof(beta), p_error);
+*
 *   hipMalloc(&buffer, buffer_size_in_bytes);
-*   rocsparse_spgeam(handle, descr, &alpha, matA, &beta, matB, matC, rocsparse_spgeam_stage_compute, buffer_size_in_bytes, buffer, p_error);
+*   rocsparse_spgeam(handle, descr, matA, matB, matC, rocsparse_spgeam_stage_compute, buffer_size_in_bytes, buffer, p_error);
 *   hipFree(buffer);
 *
 *   // Copy C matrix result back to host
@@ -462,6 +457,10 @@ rocsparse_status rocsparse_spgeam_buffer_size(rocsparse_handle            handle
 *   const rocsparse_datatype scalar_datatype = rocsparse_datatype_f32_r;
 *   rocsparse_spgeam_set_input(handle, descr, rocsparse_spgeam_input_scalar_datatype, &scalar_datatype, sizeof(scalar_datatype), p_error);
 *
+*   // Set alpha and beta.
+*   rocsparse_spgeam_set_input(handle, descr, rocsparse_spgeam_input_scalar_A, &alpha, sizeof(alpha), p_error);
+*   rocsparse_spgeam_set_input(handle, descr, rocsparse_spgeam_input_scalar_B, &beta, sizeof(beta), p_error);
+*
 *   // Set the compute type on the descriptor
 *   const rocsparse_datatype compute_datatype = rocsparse_datatype_f32_r;
 *   rocsparse_spgeam_set_input(handle, descr, rocsparse_spgeam_input_compute_datatype, &compute_datatype, sizeof(compute_datatype), p_error);
@@ -469,10 +468,10 @@ rocsparse_status rocsparse_spgeam_buffer_size(rocsparse_handle            handle
 *   // Calculate NNZ phase
 *   size_t buffer_size_in_bytes;
 *   void * buffer;
-*   rocsparse_spgeam_buffer_size(handle, descr, matA, matB, nullptr, rocsparse_spgeam_stage_analysis, &buffer_size_in_bytes, p_error);
+*   rocsparse_spgeam_buffer_size(handle, descr, matA, matB, nullptr, rocsparse_spgeam_stage_symbolic_analysis, &buffer_size_in_bytes, p_error);
 *
 *   hipMalloc(&buffer, buffer_size_in_bytes);
-*   rocsparse_spgeam(handle, descr, &alpha, matA, &beta, matB, nullptr, rocsparse_spgeam_stage_analysis, buffer_size_in_bytes, buffer, p_error);
+*   rocsparse_spgeam(handle, descr, matA, matB, nullptr, rocsparse_spgeam_stage_symbolic_analysis, buffer_size_in_bytes, buffer, p_error);
 *   hipFree(buffer);
 *
 *   // Ensure analysis stage is complete before grabbing C non-zero count
@@ -499,14 +498,20 @@ rocsparse_status rocsparse_spgeam_buffer_size(rocsparse_handle            handle
 *   rocsparse_spgeam_buffer_size(handle, descr, matA, matB, matC, rocsparse_spgeam_stage_symbolic_compute, &buffer_size_in_bytes, p_error);
 *
 *   hipMalloc(&buffer, buffer_size_in_bytes);
-*   rocsparse_spgeam(handle, descr, &alpha, matA, &beta, matB, matC, rocsparse_spgeam_stage_symbolic_compute, buffer_size_in_bytes, buffer, p_error);
+*   rocsparse_spgeam(handle, descr, matA, matB, matC, rocsparse_spgeam_stage_symbolic_compute, buffer_size_in_bytes, buffer, p_error);
+*   hipFree(buffer);
+*
+*   rocsparse_spgeam_buffer_size(handle, descr, matA, matB, matC, rocsparse_spgeam_stage_numeric_analysis, &buffer_size_in_bytes, p_error);
+*
+*   hipMalloc(&buffer, buffer_size_in_bytes);
+*   rocsparse_spgeam(handle, descr, matA, matB, matC, rocsparse_spgeam_stage_numeric_analysis, buffer_size_in_bytes, buffer, p_error);
 *   hipFree(buffer);
 *
 *   // First Numeric compute phase
 *   rocsparse_spgeam_buffer_size(handle, descr, matA, matB, matC, rocsparse_spgeam_stage_numeric_compute, &buffer_size_in_bytes, p_error);
 *
 *   hipMalloc(&buffer, buffer_size_in_bytes);
-*   rocsparse_spgeam(handle, descr, &alpha, matA, &beta, matB, matC, rocsparse_spgeam_stage_numeric_compute, buffer_size_in_bytes, buffer, p_error);
+*   rocsparse_spgeam(handle, descr, matA, matB, matC, rocsparse_spgeam_stage_numeric_compute, buffer_size_in_bytes, buffer, p_error);
 *   hipFree(buffer);
 *
 *
@@ -515,7 +520,7 @@ rocsparse_status rocsparse_spgeam_buffer_size(rocsparse_handle            handle
 *   hcsr_val_B[1] += 0.5;
 *   hipMemcpy(dcsr_val_B, hcsr_val_B.data(), nnz_B * sizeof(float), hipMemcpyHostToDevice);
 *   hipMalloc(&buffer, buffer_size_in_bytes);
-*   rocsparse_spgeam(handle, descr, &alpha, matA, &beta, matB, matC, rocsparse_spgeam_stage_numeric_compute, buffer_size_in_bytes, buffer, p_error);
+*   rocsparse_spgeam(handle, descr, matA, matB, matC, rocsparse_spgeam_stage_numeric_compute, buffer_size_in_bytes, buffer, p_error);
 *   hipFree(buffer);
 *
 *   // Copy C matrix result back to host
@@ -552,9 +557,7 @@ rocsparse_status rocsparse_spgeam_buffer_size(rocsparse_handle            handle
 ROCSPARSE_EXPORT
 rocsparse_status rocsparse_spgeam(rocsparse_handle            handle,
                                   rocsparse_spgeam_descr      descr,
-                                  const void*                 alpha,
                                   rocsparse_const_spmat_descr mat_A,
-                                  const void*                 beta,
                                   rocsparse_const_spmat_descr mat_B,
                                   rocsparse_spmat_descr       mat_C,
                                   rocsparse_spgeam_stage      stage,

--- a/library/include/rocsparse-types.h
+++ b/library/include/rocsparse-types.h
@@ -977,8 +977,8 @@ typedef enum rocsparse_spgeam_input_
     rocsparse_spgeam_input_compute_datatype, /**< Select compute data type for input on SpGEAM descriptor. */
     rocsparse_spgeam_input_operation_A, /**< Select A matrix transpose operation for input on SpGEAM descriptor. */
     rocsparse_spgeam_input_operation_B, /**< Select B matrix transpose operation for input on SpGEAM descriptor. */
-    rocsparse_spgeam_input_scalar_A, /**< Select scalar multiplier of matrix A for input on SpGEAM descriptor. */
-    rocsparse_spgeam_input_scalar_B /**< Select scalar multiplier of matrix B for input on SpGEAM descriptor. */
+    rocsparse_spgeam_input_scalar_alpha, /**< Select scalar multiplier alpha for input on SpGEAM descriptor. */
+    rocsparse_spgeam_input_scalar_beta /**< Select scalar multiplier beta for input on SpGEAM descriptor. */
 } rocsparse_spgeam_input;
 
 /*! \ingroup types_module

--- a/library/include/rocsparse-types.h
+++ b/library/include/rocsparse-types.h
@@ -954,10 +954,14 @@ typedef enum rocsparse_spgeam_stage_
 {
     rocsparse_spgeam_stage_analysis = 1, /**< Computes number of non-zero entries. */
     rocsparse_spgeam_stage_compute  = 2, /**< Performs the actual SpGEAM computation. */
+    rocsparse_spgeam_stage_symbolic_analysis
+    = 3, /**< Performs only the symbolic analysis SpGEAM computation to fill the column indices array. */
     rocsparse_spgeam_stage_symbolic_compute
-    = 3, /**< Performs only the symbolic SpGEAM computation to fill the column indices array. */
+    = 4, /**< Performs only the symbolic SpGEAM computation to fill the column indices array. */
+    rocsparse_spgeam_stage_numeric_analysis
+    = 5, /**< Performs only the numeric analysis SpGEAM computation to fill the values array. */
     rocsparse_spgeam_stage_numeric_compute
-    = 4 /**< Performs only the numeric SpGEAM computation to fill the values array. */
+    = 6 /**< Performs only the numeric SpGEAM computation to fill the values array. */
 } rocsparse_spgeam_stage;
 
 /*! \ingroup types_module
@@ -972,7 +976,9 @@ typedef enum rocsparse_spgeam_input_
     rocsparse_spgeam_input_scalar_datatype, /**< Select scalar data type for input on SpGEAM descriptor. */
     rocsparse_spgeam_input_compute_datatype, /**< Select compute data type for input on SpGEAM descriptor. */
     rocsparse_spgeam_input_operation_A, /**< Select A matrix transpose operation for input on SpGEAM descriptor. */
-    rocsparse_spgeam_input_operation_B /**< Select B matrix transpose operation for input on SpGEAM descriptor. */
+    rocsparse_spgeam_input_operation_B, /**< Select B matrix transpose operation for input on SpGEAM descriptor. */
+    rocsparse_spgeam_input_scalar_A, /**< Select scalar multiplier of matrix A for input on SpGEAM descriptor. */
+    rocsparse_spgeam_input_scalar_B /**< Select scalar multiplier of matrix B for input on SpGEAM descriptor. */
 } rocsparse_spgeam_input;
 
 /*! \ingroup types_module

--- a/library/src/auxiliary/rocsparse_auxiliary.cpp
+++ b/library/src/auxiliary/rocsparse_auxiliary.cpp
@@ -5024,7 +5024,7 @@ try
 
     switch(input)
     {
-    case rocsparse_spgeam_input_scalar_A:
+    case rocsparse_spgeam_input_scalar_alpha:
     {
         ROCSPARSE_CHECKARG(4,
                            data_size_in_bytes,
@@ -5033,7 +5033,7 @@ try
         descr->set_scalar_A(data);
         return rocsparse_status_success;
     }
-    case rocsparse_spgeam_input_scalar_B:
+    case rocsparse_spgeam_input_scalar_beta:
     {
         ROCSPARSE_CHECKARG(4,
                            data_size_in_bytes,

--- a/library/src/auxiliary/rocsparse_auxiliary.cpp
+++ b/library/src/auxiliary/rocsparse_auxiliary.cpp
@@ -5024,6 +5024,25 @@ try
 
     switch(input)
     {
+    case rocsparse_spgeam_input_scalar_A:
+    {
+        ROCSPARSE_CHECKARG(4,
+                           data_size_in_bytes,
+                           data_size_in_bytes != sizeof(void*),
+                           rocsparse_status_invalid_size);
+        descr->set_scalar_A(data);
+        return rocsparse_status_success;
+    }
+    case rocsparse_spgeam_input_scalar_B:
+    {
+        ROCSPARSE_CHECKARG(4,
+                           data_size_in_bytes,
+                           data_size_in_bytes != sizeof(void*),
+                           rocsparse_status_invalid_size);
+        descr->set_scalar_B(data);
+        return rocsparse_status_success;
+    }
+
     case rocsparse_spgeam_input_alg:
     {
         ROCSPARSE_CHECKARG(4,

--- a/library/src/extra/rocsparse_spgeam.cpp
+++ b/library/src/extra/rocsparse_spgeam.cpp
@@ -32,13 +32,8 @@
 #include "rocsparse_csrgeam_numeric.hpp"
 #include "rocsparse_csrgeam_symbolic.hpp"
 
-rocsparse_status _rocsparse_spgeam_descr::csrgeam_allocate_descr_memory(rocsparse_handle handle,
-                                                                        int64_t          m,
-                                                                        int64_t          n,
-                                                                        const void*      alpha,
-                                                                        int64_t          nnz_A,
-                                                                        const void*      beta,
-                                                                        int64_t          nnz_B)
+rocsparse_status _rocsparse_spgeam_descr::csrgeam_allocate_descr_memory(
+    rocsparse_handle handle, int64_t m, int64_t n, int64_t nnz_A, int64_t nnz_B)
 {
     ROCSPARSE_ROUTINE_TRACE;
 
@@ -126,6 +121,8 @@ const char* rocsparse::enum_utils::to_string(rocsparse_spgeam_stage value_)
         CASE(rocsparse_spgeam_stage_compute);
         CASE(rocsparse_spgeam_stage_symbolic_compute);
         CASE(rocsparse_spgeam_stage_numeric_compute);
+        CASE(rocsparse_spgeam_stage_symbolic_analysis);
+        CASE(rocsparse_spgeam_stage_numeric_analysis);
 #undef CASE
     }
     THROW_IF_ROCSPARSE_ERROR(rocsparse_status_invalid_value);
@@ -144,6 +141,8 @@ const char* rocsparse::enum_utils::to_string(rocsparse_spgeam_input value_)
         CASE(rocsparse_spgeam_input_compute_datatype);
         CASE(rocsparse_spgeam_input_operation_A);
         CASE(rocsparse_spgeam_input_operation_B);
+        CASE(rocsparse_spgeam_input_scalar_A);
+        CASE(rocsparse_spgeam_input_scalar_B);
 #undef CASE
     }
     THROW_IF_ROCSPARSE_ERROR(rocsparse_status_invalid_value);
@@ -185,6 +184,8 @@ bool rocsparse::enum_utils::is_invalid(rocsparse_spgeam_stage value_)
     case rocsparse_spgeam_stage_compute:
     case rocsparse_spgeam_stage_symbolic_compute:
     case rocsparse_spgeam_stage_numeric_compute:
+    case rocsparse_spgeam_stage_symbolic_analysis:
+    case rocsparse_spgeam_stage_numeric_analysis:
     {
         return false;
     }
@@ -202,6 +203,8 @@ bool rocsparse::enum_utils::is_invalid(rocsparse_spgeam_input value_)
     case rocsparse_spgeam_input_compute_datatype:
     case rocsparse_spgeam_input_operation_A:
     case rocsparse_spgeam_input_operation_B:
+    case rocsparse_spgeam_input_scalar_A:
+    case rocsparse_spgeam_input_scalar_B:
     {
         return false;
     }
@@ -291,6 +294,11 @@ namespace rocsparse
         const rocsparse_format format_A = mat_A->format;
         switch(stage)
         {
+        case rocsparse_spgeam_stage_numeric_analysis:
+        {
+            *buffer_size = 0;
+        }
+        case rocsparse_spgeam_stage_symbolic_analysis:
         case rocsparse_spgeam_stage_analysis:
         {
             switch(format_A)
@@ -400,70 +408,68 @@ namespace rocsparse
 
     static rocsparse_status spgeam_checkarg(rocsparse_handle            handle, //0
                                             rocsparse_spgeam_descr      descr, //1
-                                            const void*                 alpha, //2
-                                            rocsparse_const_spmat_descr mat_A, //3
-                                            const void*                 beta, //4
-                                            rocsparse_const_spmat_descr mat_B, //5
-                                            rocsparse_spmat_descr       mat_C, //6
-                                            rocsparse_spgeam_stage      stage, //7
-                                            size_t                      buffer_size, //8
-                                            void*                       temp_buffer) //9
+                                            rocsparse_const_spmat_descr mat_A, //2
+                                            rocsparse_const_spmat_descr mat_B, //3
+                                            rocsparse_spmat_descr       mat_C, //4
+                                            rocsparse_spgeam_stage      stage, //5
+                                            size_t                      buffer_size, //6
+                                            void*                       temp_buffer) //7
     {
         ROCSPARSE_ROUTINE_TRACE;
         ROCSPARSE_CHECKARG_HANDLE(0, handle);
 
         ROCSPARSE_CHECKARG_POINTER(1, descr);
-        ROCSPARSE_CHECKARG_POINTER(3, mat_A);
-        ROCSPARSE_CHECKARG_POINTER(5, mat_B);
+        ROCSPARSE_CHECKARG_POINTER(2, mat_A);
+        ROCSPARSE_CHECKARG_POINTER(3, mat_B);
         if(stage == rocsparse_spgeam_stage_compute
            || stage == rocsparse_spgeam_stage_symbolic_compute
            || stage == rocsparse_spgeam_stage_numeric_compute)
         {
-            ROCSPARSE_CHECKARG_POINTER(6, mat_C);
+            ROCSPARSE_CHECKARG_POINTER(4, mat_C);
         }
-        ROCSPARSE_CHECKARG(9,
+        ROCSPARSE_CHECKARG(7,
                            temp_buffer,
                            (buffer_size > 0 && temp_buffer == nullptr),
                            rocsparse_status_invalid_pointer);
 
-        ROCSPARSE_CHECKARG_ENUM(7, stage);
+        ROCSPARSE_CHECKARG_ENUM(5, stage);
 
-        ROCSPARSE_CHECKARG(3, mat_A, (mat_A->init == false), rocsparse_status_not_initialized);
-        ROCSPARSE_CHECKARG(5, mat_B, (mat_B->init == false), rocsparse_status_not_initialized);
+        ROCSPARSE_CHECKARG(2, mat_A, (mat_A->init == false), rocsparse_status_not_initialized);
+        ROCSPARSE_CHECKARG(3, mat_B, (mat_B->init == false), rocsparse_status_not_initialized);
 
         ROCSPARSE_CHECKARG(
-            5, mat_B, (mat_B->format != mat_A->format), rocsparse_status_not_implemented);
-        ROCSPARSE_CHECKARG(3,
+            3, mat_B, (mat_B->format != mat_A->format), rocsparse_status_not_implemented);
+        ROCSPARSE_CHECKARG(2,
                            mat_A,
                            (mat_A->data_type != descr->get_compute_datatype()),
                            rocsparse_status_not_implemented);
-        ROCSPARSE_CHECKARG(5,
+        ROCSPARSE_CHECKARG(3,
                            mat_B,
                            (mat_B->data_type != descr->get_compute_datatype()),
                            rocsparse_status_not_implemented);
 
         ROCSPARSE_CHECKARG(
-            5, mat_B, (mat_B->row_type != mat_A->row_type), rocsparse_status_type_mismatch);
+            3, mat_B, (mat_B->row_type != mat_A->row_type), rocsparse_status_type_mismatch);
         ROCSPARSE_CHECKARG(
-            5, mat_B, (mat_B->col_type != mat_A->col_type), rocsparse_status_type_mismatch);
+            3, mat_B, (mat_B->col_type != mat_A->col_type), rocsparse_status_type_mismatch);
 
         if(stage == rocsparse_spgeam_stage_compute
            || stage == rocsparse_spgeam_stage_symbolic_compute
            || stage == rocsparse_spgeam_stage_numeric_compute || mat_C != nullptr)
         {
-            ROCSPARSE_CHECKARG(6, mat_C, (mat_C->init == false), rocsparse_status_not_initialized);
+            ROCSPARSE_CHECKARG(4, mat_C, (mat_C->init == false), rocsparse_status_not_initialized);
 
             ROCSPARSE_CHECKARG(
-                6, mat_C, (mat_C->format != mat_A->format), rocsparse_status_not_implemented);
-            ROCSPARSE_CHECKARG(6,
+                4, mat_C, (mat_C->format != mat_A->format), rocsparse_status_not_implemented);
+            ROCSPARSE_CHECKARG(4,
                                mat_C,
                                (mat_C->data_type != descr->get_compute_datatype()),
                                rocsparse_status_not_implemented);
 
             ROCSPARSE_CHECKARG(
-                6, mat_C, (mat_C->row_type != mat_A->row_type), rocsparse_status_type_mismatch);
+                4, mat_C, (mat_C->row_type != mat_A->row_type), rocsparse_status_type_mismatch);
             ROCSPARSE_CHECKARG(
-                6, mat_C, (mat_C->col_type != mat_A->col_type), rocsparse_status_type_mismatch);
+                4, mat_C, (mat_C->col_type != mat_A->col_type), rocsparse_status_type_mismatch);
         }
 
         // Validate spgeam descriptor inputs.
@@ -496,6 +502,130 @@ namespace rocsparse
         // Validate the stage.
         switch(stage)
         {
+        case rocsparse_spgeam_stage_symbolic_analysis:
+        {
+
+            switch(previous_stage)
+            {
+
+            case rocsparse_spgeam_stage_symbolic_analysis:
+            {
+                RETURN_WITH_MESSAGE_IF_ROCSPARSE_ERROR(
+                    rocsparse_status_invalid_value,
+                    "invalid stage, the stage rocsparse_spgeam_stage_symbolic_analysis has already "
+                    "been "
+                    "executed");
+            }
+
+            case rocsparse_spgeam_stage_analysis:
+            {
+                RETURN_WITH_MESSAGE_IF_ROCSPARSE_ERROR(
+                    rocsparse_status_invalid_value,
+                    "invalid stage, the stage rocsparse_spgeam_stage_symbolic_analysis cannot be "
+                    "called "
+                    "after "
+                    "the stage rocsparse_spgeam_stage_analysis");
+            }
+
+            case rocsparse_spgeam_stage_compute:
+            {
+                RETURN_WITH_MESSAGE_IF_ROCSPARSE_ERROR(
+                    rocsparse_status_invalid_value,
+                    "invalid stage, the stage rocsparse_spgeam_stage_symbolic_analysis cannot be "
+                    "called "
+                    "after "
+                    "the stage rocsparse_spgeam_stage_compute");
+            }
+
+            case rocsparse_spgeam_stage_numeric_analysis:
+            {
+                RETURN_WITH_MESSAGE_IF_ROCSPARSE_ERROR(
+                    rocsparse_status_invalid_value,
+                    "invalid stage, the stage rocsparse_spgeam_stage_symbolic_analysis cannot be "
+                    "called "
+                    "after "
+                    "the stage rocsparse_spgeam_stage_numeric_analysis");
+            }
+
+            case rocsparse_spgeam_stage_numeric_compute:
+            {
+                RETURN_WITH_MESSAGE_IF_ROCSPARSE_ERROR(
+                    rocsparse_status_invalid_value,
+                    "invalid stage, the stage rocsparse_spgeam_stage_symbolic_analysis cannot be "
+                    "called "
+                    "after "
+                    "the stage rocsparse_spgeam_stage_numeric_compute");
+            }
+
+            case rocsparse_spgeam_stage_symbolic_compute:
+            {
+                RETURN_WITH_MESSAGE_IF_ROCSPARSE_ERROR(
+                    rocsparse_status_invalid_value,
+                    "invalid stage, the stage rocsparse_spgeam_stage_symbolic_analysis cannot be "
+                    "called "
+                    "after "
+                    "the stage rocsparse_spgeam_stage_symbolic_compute");
+            }
+            }
+
+            break;
+        }
+
+        case rocsparse_spgeam_stage_numeric_analysis:
+        {
+
+            switch(previous_stage)
+            {
+
+            case rocsparse_spgeam_stage_numeric_compute:
+            case rocsparse_spgeam_stage_symbolic_compute:
+            {
+                break;
+            }
+
+            case rocsparse_spgeam_stage_symbolic_analysis:
+            {
+                RETURN_WITH_MESSAGE_IF_ROCSPARSE_ERROR(
+                    rocsparse_status_invalid_value,
+                    "invalid stage, the stage rocsparse_spgeam_stage_numeric_analysis cannot be "
+                    "called "
+                    "after "
+                    "the stage rocsparse_spgeam_stage_symbolic_analysis");
+            }
+
+            case rocsparse_spgeam_stage_analysis:
+            {
+                RETURN_WITH_MESSAGE_IF_ROCSPARSE_ERROR(
+                    rocsparse_status_invalid_value,
+                    "invalid stage, the stage rocsparse_spgeam_stage_numeric_analysis cannot be "
+                    "called "
+                    "after "
+                    "the stage rocsparse_spgeam_stage_analysis");
+            }
+
+            case rocsparse_spgeam_stage_compute:
+            {
+                RETURN_WITH_MESSAGE_IF_ROCSPARSE_ERROR(
+                    rocsparse_status_invalid_value,
+                    "invalid stage, the stage rocsparse_spgeam_stage_numeric_analysis cannot be "
+                    "called "
+                    "after "
+                    "the stage rocsparse_spgeam_stage_compute");
+            }
+
+            case rocsparse_spgeam_stage_numeric_analysis:
+            {
+                RETURN_WITH_MESSAGE_IF_ROCSPARSE_ERROR(
+                    rocsparse_status_invalid_value,
+                    "invalid stage, the stage rocsparse_spgeam_stage_numeric_analysis has already "
+                    "been "
+                    "executed");
+            }
+            }
+
+            break;
+        }
+
         case rocsparse_spgeam_stage_symbolic_compute:
         {
 
@@ -510,9 +640,18 @@ namespace rocsparse
 
             switch(previous_stage)
             {
+            case rocsparse_spgeam_stage_symbolic_analysis:
+            {
+                break;
+            }
 
             case rocsparse_spgeam_stage_analysis:
             {
+                RETURN_WITH_MESSAGE_IF_ROCSPARSE_ERROR(
+                    rocsparse_status_invalid_value,
+                    "invalid stage, the stage rocsparse_spgeam_stage_symbolic_compute cannot be "
+                    "called "
+                    "after the stage rocsparse_spgeam_stage_analysis");
                 break;
             }
 
@@ -523,6 +662,15 @@ namespace rocsparse
                     "invalid stage, the stage rocsparse_spgeam_stage_symbolic_compute cannot be "
                     "called "
                     "after the stage rocsparse_spgeam_stage_compute");
+            }
+
+            case rocsparse_spgeam_stage_numeric_analysis:
+            {
+                RETURN_WITH_MESSAGE_IF_ROCSPARSE_ERROR(
+                    rocsparse_status_invalid_value,
+                    "invalid stage, the stage rocsparse_spgeam_stage_symbolic_compute cannot be "
+                    "called "
+                    "after the stage rocsparse_spgeam_stage_numeric_analysis");
             }
 
             case rocsparse_spgeam_stage_numeric_compute:
@@ -550,6 +698,24 @@ namespace rocsparse
         {
             switch(previous_stage)
             {
+            case rocsparse_spgeam_stage_symbolic_analysis:
+            {
+                RETURN_WITH_MESSAGE_IF_ROCSPARSE_ERROR(
+                    rocsparse_status_invalid_value,
+                    "invalid stage, the stage rocsparse_spgeam_stage_numeric_compute cannot be "
+                    "called "
+                    "after the stage rocsparse_spgeam_stage_symbolic_analysis");
+            }
+
+            case rocsparse_spgeam_stage_analysis:
+            {
+                RETURN_WITH_MESSAGE_IF_ROCSPARSE_ERROR(
+                    rocsparse_status_invalid_value,
+                    "invalid stage, the stage rocsparse_spgeam_stage_numeric_compute cannot be "
+                    "called "
+                    "after the stage rocsparse_spgeam_stage_analysis");
+            }
+
             case rocsparse_spgeam_stage_compute:
             {
                 RETURN_WITH_MESSAGE_IF_ROCSPARSE_ERROR(
@@ -559,7 +725,7 @@ namespace rocsparse
                     "after the stage rocsparse_spgeam_stage_compute");
             }
 
-            case rocsparse_spgeam_stage_analysis:
+            case rocsparse_spgeam_stage_numeric_analysis:
             case rocsparse_spgeam_stage_numeric_compute:
             case rocsparse_spgeam_stage_symbolic_compute:
             {
@@ -589,6 +755,24 @@ namespace rocsparse
                     "invalid stage, the stage rocsparse_spgeam_stage_analysis cannot be called "
                     "after "
                     "the stage rocsparse_spgeam_stage_compute");
+            }
+
+            case rocsparse_spgeam_stage_numeric_analysis:
+            {
+                RETURN_WITH_MESSAGE_IF_ROCSPARSE_ERROR(
+                    rocsparse_status_invalid_value,
+                    "invalid stage, the stage rocsparse_spgeam_stage_analysis cannot be called "
+                    "after "
+                    "the stage rocsparse_spgeam_stage_numeric_analysis");
+            }
+
+            case rocsparse_spgeam_stage_symbolic_analysis:
+            {
+                RETURN_WITH_MESSAGE_IF_ROCSPARSE_ERROR(
+                    rocsparse_status_invalid_value,
+                    "invalid stage, the stage rocsparse_spgeam_stage_analysis cannot be called "
+                    "after "
+                    "the stage rocsparse_spgeam_stage_symbolic_analysis");
             }
 
             case rocsparse_spgeam_stage_numeric_compute:
@@ -647,6 +831,22 @@ namespace rocsparse
                     "invalid stage, the stage rocsparse_spgeam_stage_compute cannot be called "
                     "after the stage rocsparse_spgeam_stage_symbolic_compute");
             }
+
+            case rocsparse_spgeam_stage_numeric_analysis:
+            {
+                RETURN_WITH_MESSAGE_IF_ROCSPARSE_ERROR(
+                    rocsparse_status_invalid_value,
+                    "invalid stage, the stage rocsparse_spgeam_stage_compute cannot be called "
+                    "after the stage rocsparse_spgeam_stage_numeric_analysis");
+            }
+
+            case rocsparse_spgeam_stage_symbolic_analysis:
+            {
+                RETURN_WITH_MESSAGE_IF_ROCSPARSE_ERROR(
+                    rocsparse_status_invalid_value,
+                    "invalid stage, the stage rocsparse_spgeam_stage_compute cannot be called "
+                    "after the stage rocsparse_spgeam_stage_symbolic_analysis");
+            }
             }
 
             break;
@@ -658,9 +858,7 @@ namespace rocsparse
 
     static rocsparse_status spgeam(rocsparse_handle             handle,
                                    const rocsparse_spgeam_descr descr,
-                                   const void*                  alpha,
                                    rocsparse_const_spmat_descr  mat_A,
-                                   const void*                  beta,
                                    rocsparse_const_spmat_descr  mat_B,
                                    rocsparse_spmat_descr        mat_C,
                                    rocsparse_spgeam_stage       stage,
@@ -671,6 +869,15 @@ namespace rocsparse
         const rocsparse_format format_A = mat_A->format;
         switch(stage)
         {
+        case rocsparse_spgeam_stage_numeric_analysis:
+        {
+            //
+            // do nothing.
+            //
+            return rocsparse_status_success;
+        }
+
+        case rocsparse_spgeam_stage_symbolic_analysis:
         case rocsparse_spgeam_stage_analysis:
         {
             switch(format_A)
@@ -680,7 +887,7 @@ namespace rocsparse
                 if(mat_C == nullptr)
                 {
                     RETURN_IF_ROCSPARSE_ERROR(descr->csrgeam_allocate_descr_memory(
-                        handle, mat_A->rows, mat_B->cols, alpha, mat_A->nnz, beta, mat_B->nnz));
+                        handle, mat_A->rows, mat_B->cols, mat_A->nnz, mat_B->nnz));
                 }
 
                 RETURN_IF_ROCSPARSE_ERROR(rocsparse::csrgeam_nnz(
@@ -732,10 +939,25 @@ namespace rocsparse
 
         case rocsparse_spgeam_stage_compute:
         {
-            const void* local_alpha = alpha;
-            const void* local_beta  = beta;
-            RETURN_IF_ROCSPARSE_ERROR(
-                convert_scalars(handle, descr, alpha, beta, &local_alpha, &local_beta));
+
+            const void* local_alpha = descr->get_scalar_A();
+            const void* local_beta  = descr->get_scalar_B();
+
+            RETURN_WITH_MESSAGE_IF_ROCSPARSE_ERROR(
+                (local_alpha == nullptr) ? rocsparse_status_invalid_pointer
+                                         : rocsparse_status_success,
+                "rocsparse_spgeam_input_scalar_A must be set up.");
+            RETURN_WITH_MESSAGE_IF_ROCSPARSE_ERROR(
+                (local_beta == nullptr) ? rocsparse_status_invalid_pointer
+                                        : rocsparse_status_success,
+                "rocsparse_spgeam_input_scalar_B must be set up.");
+
+            RETURN_IF_ROCSPARSE_ERROR(convert_scalars(handle,
+                                                      descr,
+                                                      descr->get_scalar_A(),
+                                                      descr->get_scalar_B(),
+                                                      &local_alpha,
+                                                      &local_beta));
 
             switch(format_A)
             {
@@ -851,10 +1073,26 @@ namespace rocsparse
 
         case rocsparse_spgeam_stage_numeric_compute:
         {
-            const void* local_alpha = alpha;
-            const void* local_beta  = beta;
-            RETURN_IF_ROCSPARSE_ERROR(
-                convert_scalars(handle, descr, alpha, beta, &local_alpha, &local_beta));
+
+            const void* local_alpha = descr->get_scalar_A();
+            const void* local_beta  = descr->get_scalar_B();
+
+            RETURN_WITH_MESSAGE_IF_ROCSPARSE_ERROR(
+                (local_alpha == nullptr) ? rocsparse_status_invalid_pointer
+                                         : rocsparse_status_success,
+                "rocsparse_spgeam_input_scalar_A must be set up.");
+
+            RETURN_WITH_MESSAGE_IF_ROCSPARSE_ERROR(
+                (local_beta == nullptr) ? rocsparse_status_invalid_pointer
+                                        : rocsparse_status_success,
+                "rocsparse_spgeam_input_scalar_B must be set up.");
+
+            RETURN_IF_ROCSPARSE_ERROR(convert_scalars(handle,
+                                                      descr,
+                                                      descr->get_scalar_A(),
+                                                      descr->get_scalar_B(),
+                                                      &local_alpha,
+                                                      &local_beta));
 
             switch(format_A)
             {
@@ -954,9 +1192,7 @@ catch(...)
 
 extern "C" rocsparse_status rocsparse_spgeam(rocsparse_handle            handle,
                                              rocsparse_spgeam_descr      descr,
-                                             const void*                 alpha,
                                              rocsparse_const_spmat_descr mat_A,
-                                             const void*                 beta,
                                              rocsparse_const_spmat_descr mat_B,
                                              rocsparse_spmat_descr       mat_C,
                                              rocsparse_spgeam_stage      stage,
@@ -966,28 +1202,19 @@ extern "C" rocsparse_status rocsparse_spgeam(rocsparse_handle            handle,
 try
 {
     ROCSPARSE_ROUTINE_TRACE;
-    rocsparse::log_trace("rocsparse_spgeam",
-                         handle,
-                         descr,
-                         alpha,
-                         mat_A,
-                         beta,
-                         mat_B,
-                         mat_C,
-                         stage,
-                         buffer_size,
-                         temp_buffer);
+    rocsparse::log_trace(
+        "rocsparse_spgeam", handle, descr, mat_A, mat_B, mat_C, stage, buffer_size, temp_buffer);
 
     const rocsparse_status status = rocsparse::spgeam_checkarg(
-        handle, descr, alpha, mat_A, beta, mat_B, mat_C, stage, buffer_size, temp_buffer);
+        handle, descr, mat_A, mat_B, mat_C, stage, buffer_size, temp_buffer);
     if(status != rocsparse_status_continue)
     {
         RETURN_IF_ROCSPARSE_ERROR(status);
         return rocsparse_status_success;
     }
 
-    RETURN_IF_ROCSPARSE_ERROR(rocsparse::spgeam(
-        handle, descr, alpha, mat_A, beta, mat_B, mat_C, stage, buffer_size, temp_buffer));
+    RETURN_IF_ROCSPARSE_ERROR(
+        rocsparse::spgeam(handle, descr, mat_A, mat_B, mat_C, stage, buffer_size, temp_buffer));
 
     // Record the stage that has been executed.
     descr->set_stage(stage);

--- a/library/src/extra/rocsparse_spgeam.cpp
+++ b/library/src/extra/rocsparse_spgeam.cpp
@@ -141,8 +141,8 @@ const char* rocsparse::enum_utils::to_string(rocsparse_spgeam_input value_)
         CASE(rocsparse_spgeam_input_compute_datatype);
         CASE(rocsparse_spgeam_input_operation_A);
         CASE(rocsparse_spgeam_input_operation_B);
-        CASE(rocsparse_spgeam_input_scalar_A);
-        CASE(rocsparse_spgeam_input_scalar_B);
+        CASE(rocsparse_spgeam_input_scalar_alpha);
+        CASE(rocsparse_spgeam_input_scalar_beta);
 #undef CASE
     }
     THROW_IF_ROCSPARSE_ERROR(rocsparse_status_invalid_value);
@@ -203,8 +203,8 @@ bool rocsparse::enum_utils::is_invalid(rocsparse_spgeam_input value_)
     case rocsparse_spgeam_input_compute_datatype:
     case rocsparse_spgeam_input_operation_A:
     case rocsparse_spgeam_input_operation_B:
-    case rocsparse_spgeam_input_scalar_A:
-    case rocsparse_spgeam_input_scalar_B:
+    case rocsparse_spgeam_input_scalar_alpha:
+    case rocsparse_spgeam_input_scalar_beta:
     {
         return false;
     }
@@ -946,11 +946,11 @@ namespace rocsparse
             RETURN_WITH_MESSAGE_IF_ROCSPARSE_ERROR(
                 (local_alpha == nullptr) ? rocsparse_status_invalid_pointer
                                          : rocsparse_status_success,
-                "rocsparse_spgeam_input_scalar_A must be set up.");
+                "rocsparse_spgeam_input_scalar_alpha must be set up.");
             RETURN_WITH_MESSAGE_IF_ROCSPARSE_ERROR(
                 (local_beta == nullptr) ? rocsparse_status_invalid_pointer
                                         : rocsparse_status_success,
-                "rocsparse_spgeam_input_scalar_B must be set up.");
+                "rocsparse_spgeam_input_scalar_beta must be set up.");
 
             RETURN_IF_ROCSPARSE_ERROR(convert_scalars(handle,
                                                       descr,
@@ -1080,12 +1080,12 @@ namespace rocsparse
             RETURN_WITH_MESSAGE_IF_ROCSPARSE_ERROR(
                 (local_alpha == nullptr) ? rocsparse_status_invalid_pointer
                                          : rocsparse_status_success,
-                "rocsparse_spgeam_input_scalar_A must be set up.");
+                "rocsparse_spgeam_input_scalar_alpha must be set up.");
 
             RETURN_WITH_MESSAGE_IF_ROCSPARSE_ERROR(
                 (local_beta == nullptr) ? rocsparse_status_invalid_pointer
                                         : rocsparse_status_success,
-                "rocsparse_spgeam_input_scalar_B must be set up.");
+                "rocsparse_spgeam_input_scalar_beta must be set up.");
 
             RETURN_IF_ROCSPARSE_ERROR(convert_scalars(handle,
                                                       descr,

--- a/library/src/include/rocsparse_spgeam_descr.hpp
+++ b/library/src/include/rocsparse_spgeam_descr.hpp
@@ -51,6 +51,8 @@ protected:
     rocsparse_datatype     compute_datatype;
     rocsparse_operation    op_A;
     rocsparse_operation    op_B;
+    const void*            scalar_A;
+    const void*            scalar_B;
 
     float m_local_host_alpha_value[4];
     float m_local_host_beta_value[4];
@@ -65,6 +67,8 @@ public:
         , compute_datatype((rocsparse_datatype)-1)
         , op_A((rocsparse_operation)-1)
         , op_B((rocsparse_operation)-1)
+        , scalar_A(nullptr)
+        , scalar_B(nullptr)
     {
     }
 
@@ -93,6 +97,17 @@ public:
     {
         return this->op_B;
     }
+
+    const void* get_scalar_A() const
+    {
+        return this->scalar_A;
+    }
+
+    const void* get_scalar_B() const
+    {
+        return this->scalar_B;
+    }
+
     rocsparse_datatype get_scalar_datatype() const
     {
         return this->scalar_datatype;
@@ -110,6 +125,7 @@ public:
     {
         this->alg = value;
     }
+
     void set_operation_A(rocsparse_operation value)
     {
         this->op_A = value;
@@ -118,6 +134,16 @@ public:
     {
         this->op_B = value;
     }
+
+    void set_scalar_A(const void* value)
+    {
+        this->scalar_A = value;
+    }
+    void set_scalar_B(const void* value)
+    {
+        this->scalar_B = value;
+    }
+
     void set_scalar_datatype(rocsparse_datatype value)
     {
         this->scalar_datatype = value;
@@ -127,13 +153,8 @@ public:
         this->compute_datatype = value;
     }
 
-    rocsparse_status csrgeam_allocate_descr_memory(rocsparse_handle handle,
-                                                   int64_t          m,
-                                                   int64_t          n,
-                                                   const void*      alpha,
-                                                   int64_t          nnz_A,
-                                                   const void*      beta,
-                                                   int64_t          nnz_B);
+    rocsparse_status csrgeam_allocate_descr_memory(
+        rocsparse_handle handle, int64_t m, int64_t n, int64_t nnz_A, int64_t nnz_B);
 
     rocsparse_status csrgeam_copy_row_pointer(rocsparse_handle          handle,
                                               int64_t                   m,


### PR DESCRIPTION
- adding stages rocsparse_spgeam_stage_symbolic_analysis rocsparse_spgeam_stage_numeric_analysis
- adding rocsparse_spgeam_input_scalar_A and rocsparse_spgeam_input_scalar_B
- removing alpha and beta from rocsparse_spgeam API
- force alpha and beta being non-null pointers.
