### PR TITLE
Use singleton class for random numbers

### DIFF
--- a/clients/common/rocsparse_random.cpp
+++ b/clients/common/rocsparse_random.cpp
@@ -50,23 +50,11 @@ rocsparse::rng_t::rng_t()
     this->reset_seed();
 }
 
-float rocsparse::rng_t::uniform_float(float a, float b)
-{
-    this->m_rand_uniform_idx = (this->m_rand_uniform_idx + 1) & (RANDOM_CACHE_SIZE - 1);
-
-    return a + this->m_rand_uniform_cache[this->m_rand_uniform_idx] * (b - a);
-}
-
 double rocsparse::rng_t::uniform_double(double a, double b)
 {
     this->m_rand_uniform_idx = (this->m_rand_uniform_idx + 1) & (RANDOM_CACHE_SIZE - 1);
 
     return a + this->m_rand_uniform_cache[this->m_rand_uniform_idx] * (b - a);
-}
-
-int32_t rocsparse::rng_t::uniform_int(int32_t a, int32_t b)
-{
-    return this->uniform_float(static_cast<float>(a), static_cast<float>(b));
 }
 
 double rocsparse::rng_t::normal_double()
@@ -111,45 +99,28 @@ rocsparse_rng_t& rocsparse::rng_t::get_rng_seed()
     return m_rng_seed;
 }
 
-void rocsparse_seedrand()
+template <typename T, typename std::enable_if_t<std::is_integral<T>::value, bool> = true>
+static T std_generator(T a, T b, rocsparse_rng_t& rng)
 {
-    rocsparse::rng_t::Instance().reset_seed();
+    return std::uniform_int_distribution<T>(a, b)(rng);
+}
+
+template <typename T, typename std::enable_if_t<!std::is_integral<T>::value, bool> = true>
+static T std_generator(T a, T b, rocsparse_rng_t& rng)
+{
+    return std::uniform_real_distribution<T>(a, b)(rng);
 }
 
 template <typename T>
-T rocsparse::rng_t::generator_exact(int32_t a, int32_t b)
-{
-    return std::uniform_int_distribution<int32_t>(a, b)(get_rng());
-}
-
-template <typename T, typename std::enable_if_t<std::is_integral<T>::value, bool>>
 T rocsparse::rng_t::generator(T a, T b)
 {
-    return generator_exact<T>(a, b);
-}
-
-template <typename T, typename std::enable_if_t<!std::is_integral<T>::value, bool>>
-T rocsparse::rng_t::generator(T a, T b)
-{
-    return std::uniform_real_distribution<T>(a, b)(get_rng());
+    return std_generator<T>(a, b, this->get_rng());
 }
 
 template <typename T>
-T rocsparse::rng_t::cached_generator_exact(int32_t a, int32_t b)
-{
-    return this->uniform_int(a, b);
-}
-
-template <typename T, typename std::enable_if_t<std::is_integral<T>::value, bool>>
 T rocsparse::rng_t::cached_generator(T a, T b)
 {
-    return this->cached_generator_exact<T>(a, b);
-}
-
-template <typename T, typename std::enable_if_t<!std::is_integral<T>::value, bool>>
-T rocsparse::rng_t::cached_generator(T a, T b)
-{
-    return static_cast<T>(this->uniform_float(a, b));
+    return static_cast<T>(this->uniform_double(a, b));
 }
 
 template <typename T>
@@ -158,45 +129,38 @@ T rocsparse::rng_t::cached_generator_normal()
     return static_cast<T>(this->normal_double());
 }
 
-template int32_t rocsparse::rng_t::generator_exact<int32_t>(int a, int b);
-template int64_t rocsparse::rng_t::generator_exact<int64_t>(int a, int b);
+template int32_t rocsparse::rng_t::generator<int32_t>(int32_t a, int32_t b);
+template int64_t rocsparse::rng_t::generator<int64_t>(int64_t a, int64_t b);
+template float   rocsparse::rng_t::generator<float>(float a, float b);
+template double  rocsparse::rng_t::generator<double>(double a, double b);
 
-template int8_t   rocsparse::rng_t::cached_generator<int8_t, true>(int8_t a, int8_t b);
-template int32_t  rocsparse::rng_t::cached_generator<int32_t, true>(int32_t a, int32_t b);
-template int64_t  rocsparse::rng_t::cached_generator<int64_t, true>(int64_t a, int64_t b);
-template uint64_t rocsparse::rng_t::cached_generator<uint64_t, true>(uint64_t a, uint64_t b);
-template _Float16 rocsparse::rng_t::cached_generator<_Float16, true>(_Float16 a, _Float16 b);
+template int8_t   rocsparse::rng_t::cached_generator<int8_t>(int8_t a, int8_t b);
+template int32_t  rocsparse::rng_t::cached_generator<int32_t>(int32_t a, int32_t b);
+template int64_t  rocsparse::rng_t::cached_generator<int64_t>(int64_t a, int64_t b);
+template uint64_t rocsparse::rng_t::cached_generator<uint64_t>(uint64_t a, uint64_t b);
+template _Float16 rocsparse::rng_t::cached_generator<_Float16>(_Float16 a, _Float16 b);
 template rocsparse_bfloat16
-               rocsparse::rng_t::cached_generator<rocsparse_bfloat16, true>(rocsparse_bfloat16 a,
-                                                                 rocsparse_bfloat16 b);
-template float rocsparse::rng_t::cached_generator<float, true>(float a, float b);
-
-template int8_t             rocsparse::rng_t::cached_generator_exact<int8_t>(int a, int b);
-template int32_t            rocsparse::rng_t::cached_generator_exact<int32_t>(int a, int b);
-template int64_t            rocsparse::rng_t::cached_generator_exact<int64_t>(int a, int b);
-template uint64_t           rocsparse::rng_t::cached_generator_exact<uint64_t>(int a, int b);
-template _Float16           rocsparse::rng_t::cached_generator_exact<_Float16>(int a, int b);
-template rocsparse_bfloat16 rocsparse::rng_t::cached_generator_exact<rocsparse_bfloat16>(int a,
-                                                                                         int b);
+                rocsparse::rng_t::cached_generator<rocsparse_bfloat16>(rocsparse_bfloat16 a,
+                                                           rocsparse_bfloat16 b);
+template float  rocsparse::rng_t::cached_generator<float>(float a, float b);
+template double rocsparse::rng_t::cached_generator<double>(double a, double b);
 
 template float  rocsparse::rng_t::cached_generator_normal<float>();
 template double rocsparse::rng_t::cached_generator_normal<double>();
 
-template int32_t rocsparse::rng_t::generator<int32_t, true>(int32_t a, int32_t b);
+// template <>
+// rocsparse_float_complex rocsparse::rng_t::generator<rocsparse_float_complex>(rocsparse_float_complex a, rocsparse_float_complex b)
+// {
+//     return rocsparse_float_complex(rocsparse::rng_t::generator<float>(std::real(a), std::real(b)),
+//                                    rocsparse::rng_t::generator<float>(std::real(a), std::real(b)));
+// }
 
-template <>
-rocsparse_float_complex rocsparse::rng_t::generator_exact<rocsparse_float_complex>(int a, int b)
-{
-    return rocsparse_float_complex(rocsparse::rng_t::generator_exact<float>(a, b),
-                                   rocsparse::rng_t::generator_exact<float>(a, b));
-}
-
-template <>
-rocsparse_double_complex rocsparse::rng_t::generator_exact<rocsparse_double_complex>(int a, int b)
-{
-    return rocsparse_double_complex(rocsparse::rng_t::generator_exact<double>(a, b),
-                                    rocsparse::rng_t::generator_exact<double>(a, b));
-}
+// template <>
+// rocsparse_double_complex rocsparse::rng_t::generator<rocsparse_double_complex>(rocsparse_double_complex a, rocsparse_double_complex b)
+// {
+//     return rocsparse_double_complex(rocsparse::rng_t::generator<double>(std::real(a), std::real(b)),
+//                                     rocsparse::rng_t::generator<double>(std::real(a), std::real(b)));
+// }
 
 template <>
 rocsparse_float_complex
@@ -220,39 +184,19 @@ rocsparse_double_complex
     return rocsparse_double_complex(r * cos(theta), r * sin(theta));
 }
 
-template <>
-float rocsparse::rng_t::cached_generator_exact(int a, int b)
-{
-    return static_cast<float>(rocsparse::rng_t::uniform_int(a, b));
-}
+// template <>
+// rocsparse_float_complex rocsparse::rng_t::cached_generator<rocsparse_float_complex>(rocsparse_float_complex a, rocsparse_float_complex b)
+// {
+//     return rocsparse_float_complex(rocsparse::rng_t::cached_generator<float>(a, b),
+//                                    rocsparse::rng_t::cached_generator<float>(a, b));
+// }
 
-template <>
-double rocsparse::rng_t::cached_generator_exact(int a, int b)
-{
-    return static_cast<double>(rocsparse::rng_t::uniform_int(a, b));
-}
-
-template <>
-rocsparse_float_complex rocsparse::rng_t::cached_generator_exact<rocsparse_float_complex>(int a,
-                                                                                          int b)
-{
-    return rocsparse_float_complex(rocsparse::rng_t::cached_generator_exact<float>(a, b),
-                                   rocsparse::rng_t::cached_generator_exact<float>(a, b));
-}
-
-template <>
-rocsparse_double_complex rocsparse::rng_t::cached_generator_exact<rocsparse_double_complex>(int a,
-                                                                                            int b)
-{
-    return rocsparse_double_complex(rocsparse::rng_t::cached_generator_exact<double>(a, b),
-                                    rocsparse::rng_t::cached_generator_exact<double>(a, b));
-}
-
-template <>
-double rocsparse::rng_t::cached_generator(double a, double b)
-{
-    return rocsparse::rng_t::uniform_double(a, b);
-}
+// template <>
+// rocsparse_double_complex rocsparse::rng_t::cached_generator<rocsparse_double_complex>(rocsparse_double_complex a, rocsparse_double_complex b)
+// {
+//     return rocsparse_double_complex(rocsparse::rng_t::cached_generator<double>(a, b),
+//                                     rocsparse::rng_t::cached_generator<double>(a, b));
+// }
 
 template <>
 rocsparse_float_complex
@@ -275,3 +219,105 @@ rocsparse_double_complex
 
     return rocsparse_double_complex(r * cos(theta), r * sin(theta));
 }
+
+/*
+* ===========================================================================
+*    Wrappers
+* ===========================================================================
+*/
+
+template <typename T>
+T random_generator_exact(int a, int b)
+{
+    // return rocsparse::rng_t::Instance().generator_exact<T>(a, b);
+    return rocsparse::rng_t::Instance().generator<T>(a, b);
+}
+
+template <typename T, typename std::enable_if_t<std::is_integral<T>::value, bool>>
+T random_generator(T a, T b)
+{
+    return rocsparse::rng_t::Instance().generator<T>(a, b);
+}
+
+template <typename T, typename std::enable_if_t<!std::is_integral<T>::value, bool>>
+T random_generator(T a, T b)
+{
+    return rocsparse::rng_t::Instance().generator<T>(a, b);
+}
+
+template <typename T>
+T random_cached_generator_exact(int a, int b)
+{
+    // return rocsparse::rng_t::Instance().cached_generator_exact<T>(a, b);
+    return rocsparse::rng_t::Instance().cached_generator<T>(a, b);
+}
+
+template <typename T, typename std::enable_if_t<std::is_integral<T>::value, bool>>
+T random_cached_generator(T a, T b)
+{
+    return rocsparse::rng_t::Instance().cached_generator<T>(a, b);
+}
+
+template <typename T, typename std::enable_if_t<!std::is_integral<T>::value, bool>>
+T random_cached_generator(T a, T b)
+{
+    return rocsparse::rng_t::Instance().cached_generator<T>(a, b);
+}
+
+template <typename T>
+T random_cached_generator_normal()
+{
+    return rocsparse::rng_t::Instance().cached_generator_normal<T>();
+}
+
+void rocsparse_seedrand()
+{
+    rocsparse::rng_t::Instance().reset_seed();
+}
+
+template int8_t             random_cached_generator<int8_t, true>(int8_t, int8_t);
+template int32_t            random_cached_generator<int32_t, true>(int32_t, int32_t);
+template int64_t            random_cached_generator<int64_t, true>(int64_t, int64_t);
+template uint64_t           random_cached_generator<uint64_t, true>(uint64_t, uint64_t);
+template _Float16           random_cached_generator<_Float16, true>(_Float16, _Float16);
+template rocsparse_bfloat16 random_cached_generator<rocsparse_bfloat16, true>(rocsparse_bfloat16,
+                                                                              rocsparse_bfloat16);
+template float              random_cached_generator<float, true>(float, float);
+template double             random_cached_generator<double, true>(double, double);
+template rocsparse_float_complex
+    random_cached_generator<rocsparse_float_complex, true>(rocsparse_float_complex,
+                                                           rocsparse_float_complex);
+template rocsparse_double_complex
+    random_cached_generator<rocsparse_double_complex, true>(rocsparse_double_complex,
+                                                            rocsparse_double_complex);
+
+template float  random_cached_generator_normal<float>();
+template double random_cached_generator_normal<double>();
+
+template int64_t                  random_generator_exact<int64_t>(int, int);
+template int32_t                  random_generator_exact<int32_t>(int a, int b);
+template float                    random_generator_exact<float>(int, int);
+template double                   random_generator_exact<double>(int, int);
+template rocsparse_float_complex  random_generator_exact<rocsparse_float_complex>(int, int);
+template rocsparse_double_complex random_generator_exact<rocsparse_double_complex>(int, int);
+
+template int    random_generator<int, true>(int, int);
+template float  random_generator<float, true>(float, float);
+template double random_generator<double, true>(double, double);
+template rocsparse_float_complex
+    random_generator<rocsparse_float_complex, true>(rocsparse_float_complex,
+                                                    rocsparse_float_complex);
+template rocsparse_double_complex
+    random_generator<rocsparse_double_complex, true>(rocsparse_double_complex,
+                                                     rocsparse_double_complex);
+
+template int8_t                   random_cached_generator_exact<int8_t>(int, int);
+template int32_t                  random_cached_generator_exact<int32_t>(int, int);
+template int64_t                  random_cached_generator_exact<int64_t>(int, int);
+template uint64_t                 random_cached_generator_exact<uint64_t>(int, int);
+template _Float16                 random_cached_generator_exact<_Float16>(int, int);
+template rocsparse_bfloat16       random_cached_generator_exact<rocsparse_bfloat16>(int, int);
+template float                    random_cached_generator_exact<float>(int, int);
+template double                   random_cached_generator_exact<double>(int, int);
+template rocsparse_float_complex  random_cached_generator_exact<rocsparse_float_complex>(int, int);
+template rocsparse_double_complex random_cached_generator_exact<rocsparse_double_complex>(int, int);

--- a/clients/common/rocsparse_random.cpp
+++ b/clients/common/rocsparse_random.cpp
@@ -1,6 +1,6 @@
 /*! \file */
 /* ************************************************************************
- * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -26,121 +26,220 @@
 #include "rocsparse_reproducibility.hpp"
 #include <iostream>
 
-// Random number generator
-// Note: We do not use random_device to initialize the RNG, because we want
-// repeatability in case of test failure. TODO: Add seed as an optional CLI
-// argument, and print the seed on output, to ensure repeatability.
-rocsparse_rng_t rocsparse_rng(69069);
-rocsparse_rng_t rocsparse_rng_nan(69069);
-rocsparse_rng_t rocsparse_seed(rocsparse_rng);
+#define RANDOM_CACHE_SIZE 1024
+
+rocsparse::random::random()
+    : rng(69069)
+    , rng_nan(69069)
+    , rng_seed(rng)
+{
+    rand_uniform_cache.resize(RANDOM_CACHE_SIZE);
+    rand_normal_cache.resize(RANDOM_CACHE_SIZE);
+
+    for(int i = 0; i < RANDOM_CACHE_SIZE; i++)
+    {
+        rand_uniform_cache[i] = std::uniform_real_distribution<double>(0.0, 1.0)(rng_get());
+    }
+
+    for(int i = 0; i < RANDOM_CACHE_SIZE; i++)
+    {
+        rand_normal_cache[i] = std::normal_distribution<double>(0.0, 1.0)(rng_get());
+    }
+
+    reset_seed();
+}
+
+float rocsparse::random::uniform_float(float a, float b)
+{
+    rand_uniform_idx = (rand_uniform_idx + 1) & (RANDOM_CACHE_SIZE - 1);
+
+    return a + rand_uniform_cache[rand_uniform_idx] * (b - a);
+}
+
+double rocsparse::random::uniform_double(double a, double b)
+{
+    rand_uniform_idx = (rand_uniform_idx + 1) & (RANDOM_CACHE_SIZE - 1);
+
+    return a + rand_uniform_cache[rand_uniform_idx] * (b - a);
+}
+
+int rocsparse::random::uniform_int(int a, int b)
+{
+    return uniform_float(static_cast<float>(a), static_cast<float>(b));
+}
+
+double rocsparse::random::normal_double()
+{
+    rand_normal_idx = (rand_normal_idx + 1) & (RANDOM_CACHE_SIZE - 1);
+
+    return rand_normal_cache[rand_normal_idx];
+}
 
 void rocsparse_seedrand()
 {
-    rocsparse_rng_set(rocsparse_seed_get());
-    rocsparse_rng_nan_set(rocsparse_seed_get());
-
-    rocsparse_rand_uniform_idx = 0;
-    rocsparse_rand_normal_idx  = 0;
+    rocsparse::random::Instance().reset_seed();
 }
 
-void rocsparse_rng_set(rocsparse_rng_t a)
+template <typename T>
+T rocsparse::random::random_generator_exact(int a, int b)
 {
-    rocsparse_rng = a;
+    return std::uniform_int_distribution<int>(a, b)(rng_get());
 }
 
-void rocsparse_seed_set(rocsparse_rng_t a)
+template <typename T, typename std::enable_if_t<std::is_integral<T>::value, bool>>
+T rocsparse::random::random_generator(T a, T b)
 {
-    rocsparse_seed = a;
+    return random_generator_exact<T>(a, b);
 }
 
-void rocsparse_rng_nan_set(rocsparse_rng_t a)
+template <typename T, typename std::enable_if_t<!std::is_integral<T>::value, bool>>
+T rocsparse::random::random_generator(T a, T b)
 {
-    rocsparse_rng_nan = a;
+    return std::uniform_real_distribution<T>(a, b)(rng_get());
 }
 
-rocsparse_rng_t& rocsparse_rng_get()
+template <typename T>
+T rocsparse::random::random_cached_generator_exact(int a, int b)
 {
-    return rocsparse_rng;
+    return uniform_int(a, b);
 }
 
-rocsparse_rng_t& rocsparse_seed_get()
+template <typename T, typename std::enable_if_t<std::is_integral<T>::value, bool>>
+T rocsparse::random::random_cached_generator(T a, T b)
 {
-    return rocsparse_seed;
+    return random_cached_generator_exact<T>(a, b);
 }
 
-rocsparse_rng_t& rocsparse_rng_nan_get()
+template <typename T, typename std::enable_if_t<!std::is_integral<T>::value, bool>>
+T rocsparse::random::random_cached_generator(T a, T b)
 {
-    return rocsparse_rng_nan;
+    return static_cast<T>(uniform_float(a, b));
 }
 
-#define RANDOM_CACHE_SIZE 1024
-
-int rocsparse_rand_uniform_idx;
-int rocsparse_rand_normal_idx;
-
-static int s_rand_uniform_init = 0;
-static int s_rand_normal_init  = 0;
-
-// random uniform numbers between 0.0 - 1.0
-static double s_rand_uniform_array[RANDOM_CACHE_SIZE];
-// random normal numbers between 0.0 - 1.0
-static double s_rand_normal_array[RANDOM_CACHE_SIZE];
-
-void generate_random_cache()
+template <typename T>
+T rocsparse::random::random_cached_generator_normal()
 {
-    if(!s_rand_uniform_init)
-    {
-        for(int i = 0; i < RANDOM_CACHE_SIZE; i++)
-        {
-            s_rand_uniform_array[i]
-                = std::uniform_real_distribution<double>(0.0, 1.0)(rocsparse_rng_get());
-        }
-        s_rand_uniform_init = 1;
-        if(rocsparse_reproducibility_t::instance().is_enabled())
-            rocsparse_seedrand();
-    }
-
-    if(!s_rand_normal_init)
-    {
-        for(int i = 0; i < RANDOM_CACHE_SIZE; i++)
-        {
-            s_rand_normal_array[i]
-                = std::normal_distribution<double>(0.0, 1.0)(rocsparse_rng_get());
-        }
-        s_rand_normal_init = 1;
-        if(rocsparse_reproducibility_t::instance().is_enabled())
-            rocsparse_seedrand();
-    }
+    return static_cast<T>(normal_double());
 }
 
-float rocsparse_uniform_float(float a, float b)
+template int32_t rocsparse::random::random_generator_exact<int32_t>(int a, int b);
+template int64_t rocsparse::random::random_generator_exact<int64_t>(int a, int b);
+
+template int8_t   rocsparse::random::random_cached_generator<int8_t, true>(int8_t a, int8_t b);
+template int32_t  rocsparse::random::random_cached_generator<int32_t, true>(int32_t a, int32_t b);
+template int64_t  rocsparse::random::random_cached_generator<int64_t, true>(int64_t a, int64_t b);
+template uint64_t rocsparse::random::random_cached_generator<uint64_t, true>(uint64_t a,
+                                                                             uint64_t b);
+template _Float16 rocsparse::random::random_cached_generator<_Float16, true>(_Float16 a,
+                                                                             _Float16 b);
+template rocsparse_bfloat16
+    rocsparse::random::random_cached_generator<rocsparse_bfloat16, true>(rocsparse_bfloat16 a,
+                                                                         rocsparse_bfloat16 b);
+template float rocsparse::random::random_cached_generator<float, true>(float a, float b);
+
+template int8_t   rocsparse::random::random_cached_generator_exact<int8_t>(int a, int b);
+template int32_t  rocsparse::random::random_cached_generator_exact<int32_t>(int a, int b);
+template int64_t  rocsparse::random::random_cached_generator_exact<int64_t>(int a, int b);
+template uint64_t rocsparse::random::random_cached_generator_exact<uint64_t>(int a, int b);
+template _Float16 rocsparse::random::random_cached_generator_exact<_Float16>(int a, int b);
+template rocsparse_bfloat16
+    rocsparse::random::random_cached_generator_exact<rocsparse_bfloat16>(int a, int b);
+
+template float  rocsparse::random::random_cached_generator_normal<float>();
+template double rocsparse::random::random_cached_generator_normal<double>();
+
+template int32_t rocsparse::random::random_generator<int32_t, true>(int32_t a, int32_t b);
+
+template <>
+rocsparse_float_complex rocsparse::random::random_generator_exact<rocsparse_float_complex>(int a,
+                                                                                           int b)
 {
-    generate_random_cache();
-
-    rocsparse_rand_uniform_idx = (rocsparse_rand_uniform_idx + 1) & (RANDOM_CACHE_SIZE - 1);
-
-    return a + s_rand_uniform_array[rocsparse_rand_uniform_idx] * (b - a);
+    return rocsparse_float_complex(rocsparse::random::random_generator_exact<float>(a, b),
+                                   rocsparse::random::random_generator_exact<float>(a, b));
 }
 
-double rocsparse_uniform_double(double a, double b)
+template <>
+rocsparse_double_complex rocsparse::random::random_generator_exact<rocsparse_double_complex>(int a,
+                                                                                             int b)
 {
-    generate_random_cache();
-
-    rocsparse_rand_uniform_idx = (rocsparse_rand_uniform_idx + 1) & (RANDOM_CACHE_SIZE - 1);
-
-    return a + s_rand_uniform_array[rocsparse_rand_uniform_idx] * (b - a);
+    return rocsparse_double_complex(rocsparse::random::random_generator_exact<double>(a, b),
+                                    rocsparse::random::random_generator_exact<double>(a, b));
 }
 
-int rocsparse_uniform_int(int a, int b)
+template <>
+rocsparse_float_complex
+    rocsparse::random::random_generator<rocsparse_float_complex>(rocsparse_float_complex a,
+                                                                 rocsparse_float_complex b)
 {
-    return rocsparse_uniform_float(static_cast<float>(a), static_cast<float>(b));
+    float theta = rocsparse::random::random_generator<float>(0.0f, 2.0f * acos(-1.0f));
+    float r     = rocsparse::random::random_generator<float>(std::abs(a), std::abs(b));
+
+    return rocsparse_float_complex(r * cos(theta), r * sin(theta));
 }
 
-double rocsparse_normal_double()
+template <>
+rocsparse_double_complex
+    rocsparse::random::random_generator<rocsparse_double_complex>(rocsparse_double_complex a,
+                                                                  rocsparse_double_complex b)
 {
-    generate_random_cache();
+    double theta = rocsparse::random::random_generator<double>(0.0, 2.0 * acos(-1.0));
+    double r     = rocsparse::random::random_generator<double>(std::abs(a), std::abs(b));
 
-    rocsparse_rand_normal_idx = (rocsparse_rand_normal_idx + 1) & (RANDOM_CACHE_SIZE - 1);
+    return rocsparse_double_complex(r * cos(theta), r * sin(theta));
+}
 
-    return s_rand_normal_array[rocsparse_rand_normal_idx];
+template <>
+float rocsparse::random::random_cached_generator_exact(int a, int b)
+{
+    return static_cast<float>(rocsparse::random::uniform_int(a, b));
+}
+
+template <>
+double rocsparse::random::random_cached_generator_exact(int a, int b)
+{
+    return static_cast<double>(rocsparse::random::uniform_int(a, b));
+}
+
+template <>
+rocsparse_float_complex
+    rocsparse::random::random_cached_generator_exact<rocsparse_float_complex>(int a, int b)
+{
+    return rocsparse_float_complex(rocsparse::random::random_cached_generator_exact<float>(a, b),
+                                   rocsparse::random::random_cached_generator_exact<float>(a, b));
+}
+
+template <>
+rocsparse_double_complex
+    rocsparse::random::random_cached_generator_exact<rocsparse_double_complex>(int a, int b)
+{
+    return rocsparse_double_complex(rocsparse::random::random_cached_generator_exact<double>(a, b),
+                                    rocsparse::random::random_cached_generator_exact<double>(a, b));
+}
+
+template <>
+double rocsparse::random::random_cached_generator(double a, double b)
+{
+    return rocsparse::random::uniform_double(a, b);
+}
+
+template <>
+rocsparse_float_complex
+    rocsparse::random::random_cached_generator<rocsparse_float_complex>(rocsparse_float_complex a,
+                                                                        rocsparse_float_complex b)
+{
+    float theta = rocsparse::random::random_cached_generator<float>(0.0f, 2.0f * acos(-1.0f));
+    float r     = rocsparse::random::random_cached_generator<float>(std::abs(a), std::abs(b));
+
+    return rocsparse_float_complex(r * cos(theta), r * sin(theta));
+}
+
+template <>
+rocsparse_double_complex
+    rocsparse::random::random_cached_generator<rocsparse_double_complex>(rocsparse_double_complex a,
+                                                                         rocsparse_double_complex b)
+{
+    double theta = rocsparse::random::random_cached_generator<double>(0.0, 2.0 * acos(-1.0));
+    double r     = rocsparse::random::random_cached_generator<double>(std::abs(a), std::abs(b));
+
+    return rocsparse_double_complex(r * cos(theta), r * sin(theta));
 }

--- a/clients/common/rocsparse_random.cpp
+++ b/clients/common/rocsparse_random.cpp
@@ -28,218 +28,215 @@
 
 #define RANDOM_CACHE_SIZE 1024
 
-rocsparse::random::random()
-    : rng(69069)
-    , rng_nan(69069)
-    , rng_seed(rng)
+rocsparse::rng_t::rng_t()
+    : m_rng(69069)
+    , m_rng_nan(69069)
+    , m_rng_seed(m_rng)
 {
-    rand_uniform_cache.resize(RANDOM_CACHE_SIZE);
-    rand_normal_cache.resize(RANDOM_CACHE_SIZE);
+    this->m_rand_uniform_cache.resize(RANDOM_CACHE_SIZE);
+    this->m_rand_normal_cache.resize(RANDOM_CACHE_SIZE);
 
     for(int i = 0; i < RANDOM_CACHE_SIZE; i++)
     {
-        rand_uniform_cache[i] = std::uniform_real_distribution<double>(0.0, 1.0)(rng_get());
+        this->m_rand_uniform_cache[i]
+            = std::uniform_real_distribution<double>(0.0, 1.0)(this->get_rng());
     }
 
     for(int i = 0; i < RANDOM_CACHE_SIZE; i++)
     {
-        rand_normal_cache[i] = std::normal_distribution<double>(0.0, 1.0)(rng_get());
+        this->m_rand_normal_cache[i] = std::normal_distribution<double>(0.0, 1.0)(this->get_rng());
     }
 
-    reset_seed();
+    this->reset_seed();
 }
 
-float rocsparse::random::uniform_float(float a, float b)
+float rocsparse::rng_t::uniform_float(float a, float b)
 {
-    rand_uniform_idx = (rand_uniform_idx + 1) & (RANDOM_CACHE_SIZE - 1);
+    this->m_rand_uniform_idx = (this->m_rand_uniform_idx + 1) & (RANDOM_CACHE_SIZE - 1);
 
-    return a + rand_uniform_cache[rand_uniform_idx] * (b - a);
+    return a + this->m_rand_uniform_cache[this->m_rand_uniform_idx] * (b - a);
 }
 
-double rocsparse::random::uniform_double(double a, double b)
+double rocsparse::rng_t::uniform_double(double a, double b)
 {
-    rand_uniform_idx = (rand_uniform_idx + 1) & (RANDOM_CACHE_SIZE - 1);
+    this->m_rand_uniform_idx = (this->m_rand_uniform_idx + 1) & (RANDOM_CACHE_SIZE - 1);
 
-    return a + rand_uniform_cache[rand_uniform_idx] * (b - a);
+    return a + this->m_rand_uniform_cache[this->m_rand_uniform_idx] * (b - a);
 }
 
-int rocsparse::random::uniform_int(int a, int b)
+int rocsparse::rng_t::uniform_int(int a, int b)
 {
-    return uniform_float(static_cast<float>(a), static_cast<float>(b));
+    return this->uniform_float(static_cast<float>(a), static_cast<float>(b));
 }
 
-double rocsparse::random::normal_double()
+double rocsparse::rng_t::normal_double()
 {
-    rand_normal_idx = (rand_normal_idx + 1) & (RANDOM_CACHE_SIZE - 1);
+    this->m_rand_normal_idx = (this->m_rand_normal_idx + 1) & (RANDOM_CACHE_SIZE - 1);
 
-    return rand_normal_cache[rand_normal_idx];
+    return this->m_rand_normal_cache[this->m_rand_normal_idx];
 }
 
 void rocsparse_seedrand()
 {
-    rocsparse::random::Instance().reset_seed();
+    rocsparse::rng_t::Instance().reset_seed();
 }
 
 template <typename T>
-T rocsparse::random::random_generator_exact(int a, int b)
+T rocsparse::rng_t::generator_exact(int a, int b)
 {
-    return std::uniform_int_distribution<int>(a, b)(rng_get());
+    return std::uniform_int_distribution<int>(a, b)(get_rng());
 }
 
 template <typename T, typename std::enable_if_t<std::is_integral<T>::value, bool>>
-T rocsparse::random::random_generator(T a, T b)
+T rocsparse::rng_t::generator(T a, T b)
 {
-    return random_generator_exact<T>(a, b);
+    return generator_exact<T>(a, b);
 }
 
 template <typename T, typename std::enable_if_t<!std::is_integral<T>::value, bool>>
-T rocsparse::random::random_generator(T a, T b)
+T rocsparse::rng_t::generator(T a, T b)
 {
-    return std::uniform_real_distribution<T>(a, b)(rng_get());
+    return std::uniform_real_distribution<T>(a, b)(get_rng());
 }
 
 template <typename T>
-T rocsparse::random::random_cached_generator_exact(int a, int b)
+T rocsparse::rng_t::cached_generator_exact(int a, int b)
 {
-    return uniform_int(a, b);
+    return this->uniform_int(a, b);
 }
 
 template <typename T, typename std::enable_if_t<std::is_integral<T>::value, bool>>
-T rocsparse::random::random_cached_generator(T a, T b)
+T rocsparse::rng_t::cached_generator(T a, T b)
 {
-    return random_cached_generator_exact<T>(a, b);
+    return this->cached_generator_exact<T>(a, b);
 }
 
 template <typename T, typename std::enable_if_t<!std::is_integral<T>::value, bool>>
-T rocsparse::random::random_cached_generator(T a, T b)
+T rocsparse::rng_t::cached_generator(T a, T b)
 {
-    return static_cast<T>(uniform_float(a, b));
+    return static_cast<T>(this->uniform_float(a, b));
 }
 
 template <typename T>
-T rocsparse::random::random_cached_generator_normal()
+T rocsparse::rng_t::cached_generator_normal()
 {
-    return static_cast<T>(normal_double());
+    return static_cast<T>(this->normal_double());
 }
 
-template int32_t rocsparse::random::random_generator_exact<int32_t>(int a, int b);
-template int64_t rocsparse::random::random_generator_exact<int64_t>(int a, int b);
+template int32_t rocsparse::rng_t::generator_exact<int32_t>(int a, int b);
+template int64_t rocsparse::rng_t::generator_exact<int64_t>(int a, int b);
 
-template int8_t   rocsparse::random::random_cached_generator<int8_t, true>(int8_t a, int8_t b);
-template int32_t  rocsparse::random::random_cached_generator<int32_t, true>(int32_t a, int32_t b);
-template int64_t  rocsparse::random::random_cached_generator<int64_t, true>(int64_t a, int64_t b);
-template uint64_t rocsparse::random::random_cached_generator<uint64_t, true>(uint64_t a,
-                                                                             uint64_t b);
-template _Float16 rocsparse::random::random_cached_generator<_Float16, true>(_Float16 a,
-                                                                             _Float16 b);
+template int8_t   rocsparse::rng_t::cached_generator<int8_t, true>(int8_t a, int8_t b);
+template int32_t  rocsparse::rng_t::cached_generator<int32_t, true>(int32_t a, int32_t b);
+template int64_t  rocsparse::rng_t::cached_generator<int64_t, true>(int64_t a, int64_t b);
+template uint64_t rocsparse::rng_t::cached_generator<uint64_t, true>(uint64_t a, uint64_t b);
+template _Float16 rocsparse::rng_t::cached_generator<_Float16, true>(_Float16 a, _Float16 b);
 template rocsparse_bfloat16
-    rocsparse::random::random_cached_generator<rocsparse_bfloat16, true>(rocsparse_bfloat16 a,
-                                                                         rocsparse_bfloat16 b);
-template float rocsparse::random::random_cached_generator<float, true>(float a, float b);
+               rocsparse::rng_t::cached_generator<rocsparse_bfloat16, true>(rocsparse_bfloat16 a,
+                                                                 rocsparse_bfloat16 b);
+template float rocsparse::rng_t::cached_generator<float, true>(float a, float b);
 
-template int8_t   rocsparse::random::random_cached_generator_exact<int8_t>(int a, int b);
-template int32_t  rocsparse::random::random_cached_generator_exact<int32_t>(int a, int b);
-template int64_t  rocsparse::random::random_cached_generator_exact<int64_t>(int a, int b);
-template uint64_t rocsparse::random::random_cached_generator_exact<uint64_t>(int a, int b);
-template _Float16 rocsparse::random::random_cached_generator_exact<_Float16>(int a, int b);
-template rocsparse_bfloat16
-    rocsparse::random::random_cached_generator_exact<rocsparse_bfloat16>(int a, int b);
+template int8_t             rocsparse::rng_t::cached_generator_exact<int8_t>(int a, int b);
+template int32_t            rocsparse::rng_t::cached_generator_exact<int32_t>(int a, int b);
+template int64_t            rocsparse::rng_t::cached_generator_exact<int64_t>(int a, int b);
+template uint64_t           rocsparse::rng_t::cached_generator_exact<uint64_t>(int a, int b);
+template _Float16           rocsparse::rng_t::cached_generator_exact<_Float16>(int a, int b);
+template rocsparse_bfloat16 rocsparse::rng_t::cached_generator_exact<rocsparse_bfloat16>(int a,
+                                                                                         int b);
 
-template float  rocsparse::random::random_cached_generator_normal<float>();
-template double rocsparse::random::random_cached_generator_normal<double>();
+template float  rocsparse::rng_t::cached_generator_normal<float>();
+template double rocsparse::rng_t::cached_generator_normal<double>();
 
-template int32_t rocsparse::random::random_generator<int32_t, true>(int32_t a, int32_t b);
+template int32_t rocsparse::rng_t::generator<int32_t, true>(int32_t a, int32_t b);
 
 template <>
-rocsparse_float_complex rocsparse::random::random_generator_exact<rocsparse_float_complex>(int a,
-                                                                                           int b)
+rocsparse_float_complex rocsparse::rng_t::generator_exact<rocsparse_float_complex>(int a, int b)
 {
-    return rocsparse_float_complex(rocsparse::random::random_generator_exact<float>(a, b),
-                                   rocsparse::random::random_generator_exact<float>(a, b));
+    return rocsparse_float_complex(rocsparse::rng_t::generator_exact<float>(a, b),
+                                   rocsparse::rng_t::generator_exact<float>(a, b));
 }
 
 template <>
-rocsparse_double_complex rocsparse::random::random_generator_exact<rocsparse_double_complex>(int a,
-                                                                                             int b)
+rocsparse_double_complex rocsparse::rng_t::generator_exact<rocsparse_double_complex>(int a, int b)
 {
-    return rocsparse_double_complex(rocsparse::random::random_generator_exact<double>(a, b),
-                                    rocsparse::random::random_generator_exact<double>(a, b));
+    return rocsparse_double_complex(rocsparse::rng_t::generator_exact<double>(a, b),
+                                    rocsparse::rng_t::generator_exact<double>(a, b));
 }
 
 template <>
 rocsparse_float_complex
-    rocsparse::random::random_generator<rocsparse_float_complex>(rocsparse_float_complex a,
-                                                                 rocsparse_float_complex b)
+    rocsparse::rng_t::generator<rocsparse_float_complex>(rocsparse_float_complex a,
+                                                         rocsparse_float_complex b)
 {
-    float theta = rocsparse::random::random_generator<float>(0.0f, 2.0f * acos(-1.0f));
-    float r     = rocsparse::random::random_generator<float>(std::abs(a), std::abs(b));
+    float theta = rocsparse::rng_t::generator<float>(0.0f, 2.0f * acos(-1.0f));
+    float r     = rocsparse::rng_t::generator<float>(std::abs(a), std::abs(b));
 
     return rocsparse_float_complex(r * cos(theta), r * sin(theta));
 }
 
 template <>
 rocsparse_double_complex
-    rocsparse::random::random_generator<rocsparse_double_complex>(rocsparse_double_complex a,
-                                                                  rocsparse_double_complex b)
+    rocsparse::rng_t::generator<rocsparse_double_complex>(rocsparse_double_complex a,
+                                                          rocsparse_double_complex b)
 {
-    double theta = rocsparse::random::random_generator<double>(0.0, 2.0 * acos(-1.0));
-    double r     = rocsparse::random::random_generator<double>(std::abs(a), std::abs(b));
+    double theta = rocsparse::rng_t::generator<double>(0.0, 2.0 * acos(-1.0));
+    double r     = rocsparse::rng_t::generator<double>(std::abs(a), std::abs(b));
 
     return rocsparse_double_complex(r * cos(theta), r * sin(theta));
 }
 
 template <>
-float rocsparse::random::random_cached_generator_exact(int a, int b)
+float rocsparse::rng_t::cached_generator_exact(int a, int b)
 {
-    return static_cast<float>(rocsparse::random::uniform_int(a, b));
+    return static_cast<float>(rocsparse::rng_t::uniform_int(a, b));
 }
 
 template <>
-double rocsparse::random::random_cached_generator_exact(int a, int b)
+double rocsparse::rng_t::cached_generator_exact(int a, int b)
 {
-    return static_cast<double>(rocsparse::random::uniform_int(a, b));
+    return static_cast<double>(rocsparse::rng_t::uniform_int(a, b));
+}
+
+template <>
+rocsparse_float_complex rocsparse::rng_t::cached_generator_exact<rocsparse_float_complex>(int a,
+                                                                                          int b)
+{
+    return rocsparse_float_complex(rocsparse::rng_t::cached_generator_exact<float>(a, b),
+                                   rocsparse::rng_t::cached_generator_exact<float>(a, b));
+}
+
+template <>
+rocsparse_double_complex rocsparse::rng_t::cached_generator_exact<rocsparse_double_complex>(int a,
+                                                                                            int b)
+{
+    return rocsparse_double_complex(rocsparse::rng_t::cached_generator_exact<double>(a, b),
+                                    rocsparse::rng_t::cached_generator_exact<double>(a, b));
+}
+
+template <>
+double rocsparse::rng_t::cached_generator(double a, double b)
+{
+    return rocsparse::rng_t::uniform_double(a, b);
 }
 
 template <>
 rocsparse_float_complex
-    rocsparse::random::random_cached_generator_exact<rocsparse_float_complex>(int a, int b)
+    rocsparse::rng_t::cached_generator<rocsparse_float_complex>(rocsparse_float_complex a,
+                                                                rocsparse_float_complex b)
 {
-    return rocsparse_float_complex(rocsparse::random::random_cached_generator_exact<float>(a, b),
-                                   rocsparse::random::random_cached_generator_exact<float>(a, b));
-}
-
-template <>
-rocsparse_double_complex
-    rocsparse::random::random_cached_generator_exact<rocsparse_double_complex>(int a, int b)
-{
-    return rocsparse_double_complex(rocsparse::random::random_cached_generator_exact<double>(a, b),
-                                    rocsparse::random::random_cached_generator_exact<double>(a, b));
-}
-
-template <>
-double rocsparse::random::random_cached_generator(double a, double b)
-{
-    return rocsparse::random::uniform_double(a, b);
-}
-
-template <>
-rocsparse_float_complex
-    rocsparse::random::random_cached_generator<rocsparse_float_complex>(rocsparse_float_complex a,
-                                                                        rocsparse_float_complex b)
-{
-    float theta = rocsparse::random::random_cached_generator<float>(0.0f, 2.0f * acos(-1.0f));
-    float r     = rocsparse::random::random_cached_generator<float>(std::abs(a), std::abs(b));
+    float theta = rocsparse::rng_t::cached_generator<float>(0.0f, 2.0f * acos(-1.0f));
+    float r     = rocsparse::rng_t::cached_generator<float>(std::abs(a), std::abs(b));
 
     return rocsparse_float_complex(r * cos(theta), r * sin(theta));
 }
 
 template <>
 rocsparse_double_complex
-    rocsparse::random::random_cached_generator<rocsparse_double_complex>(rocsparse_double_complex a,
-                                                                         rocsparse_double_complex b)
+    rocsparse::rng_t::cached_generator<rocsparse_double_complex>(rocsparse_double_complex a,
+                                                                 rocsparse_double_complex b)
 {
-    double theta = rocsparse::random::random_cached_generator<double>(0.0, 2.0 * acos(-1.0));
-    double r     = rocsparse::random::random_cached_generator<double>(std::abs(a), std::abs(b));
+    double theta = rocsparse::rng_t::cached_generator<double>(0.0, 2.0 * acos(-1.0));
+    double r     = rocsparse::rng_t::cached_generator<double>(std::abs(a), std::abs(b));
 
     return rocsparse_double_complex(r * cos(theta), r * sin(theta));
 }

--- a/clients/common/rocsparse_random.cpp
+++ b/clients/common/rocsparse_random.cpp
@@ -64,7 +64,7 @@ double rocsparse::rng_t::uniform_double(double a, double b)
     return a + this->m_rand_uniform_cache[this->m_rand_uniform_idx] * (b - a);
 }
 
-int rocsparse::rng_t::uniform_int(int a, int b)
+int32_t rocsparse::rng_t::uniform_int(int32_t a, int32_t b)
 {
     return this->uniform_float(static_cast<float>(a), static_cast<float>(b));
 }
@@ -76,15 +76,50 @@ double rocsparse::rng_t::normal_double()
     return this->m_rand_normal_cache[this->m_rand_normal_idx];
 }
 
+void rocsparse::rng_t::reset_seed()
+{
+    m_rand_uniform_idx = 0;
+    m_rand_normal_idx  = 0;
+
+    set_rng(m_rng_seed);
+    set_rng_nan(m_rng_seed);
+}
+
+void rocsparse::rng_t::set_rng(rocsparse_rng_t a)
+{
+    m_rng = a;
+}
+void rocsparse::rng_t::set_rng_nan(rocsparse_rng_t a)
+{
+    m_rng_nan = a;
+}
+void rocsparse::rng_t::rng_seed_set(rocsparse_rng_t a)
+{
+    m_rng_seed = a;
+}
+
+rocsparse_rng_t& rocsparse::rng_t::get_rng()
+{
+    return m_rng;
+}
+rocsparse_rng_t& rocsparse::rng_t::get_rng_nan()
+{
+    return m_rng_nan;
+}
+rocsparse_rng_t& rocsparse::rng_t::get_rng_seed()
+{
+    return m_rng_seed;
+}
+
 void rocsparse_seedrand()
 {
     rocsparse::rng_t::Instance().reset_seed();
 }
 
 template <typename T>
-T rocsparse::rng_t::generator_exact(int a, int b)
+T rocsparse::rng_t::generator_exact(int32_t a, int32_t b)
 {
-    return std::uniform_int_distribution<int>(a, b)(get_rng());
+    return std::uniform_int_distribution<int32_t>(a, b)(get_rng());
 }
 
 template <typename T, typename std::enable_if_t<std::is_integral<T>::value, bool>>
@@ -100,7 +135,7 @@ T rocsparse::rng_t::generator(T a, T b)
 }
 
 template <typename T>
-T rocsparse::rng_t::cached_generator_exact(int a, int b)
+T rocsparse::rng_t::cached_generator_exact(int32_t a, int32_t b)
 {
     return this->uniform_int(a, b);
 }

--- a/clients/include/rocsparse_random.hpp
+++ b/clients/include/rocsparse_random.hpp
@@ -51,10 +51,8 @@ namespace rocsparse
         std::vector<double> m_rand_uniform_cache;
         std::vector<double> m_rand_normal_cache;
 
-        float   uniform_float(float a, float b);
-        double  uniform_double(double a, double b);
-        int32_t uniform_int(int32_t a, int32_t b);
-        double  normal_double();
+        double uniform_double(double a, double b);
+        double normal_double();
 
     public:
         static rng_t& Instance()
@@ -73,26 +71,12 @@ namespace rocsparse
         rocsparse_rng_t& get_rng_nan();
         rocsparse_rng_t& get_rng_seed();
 
-        /*! \brief  generate a random number in range [a,b] using integer numbers*/
-        template <typename T>
-        T generator_exact(int32_t a, int32_t b);
-
         /*! \brief  generate a random number in range [a,b]*/
-        template <typename T, typename std::enable_if_t<std::is_integral<T>::value, bool> = true>
-        T generator(T a, T b);
-
-        template <typename T, typename std::enable_if_t<!std::is_integral<T>::value, bool> = true>
-        T generator(T a, T b);
-
-        /*! \brief  generate a random number in range [a,b] from a predetermined finite cache using integer numbers*/
         template <typename T>
-        T cached_generator_exact(int32_t a, int32_t b);
+        T generator(T a, T b);
 
         /*! \brief  generate a random number in range [a,b] from a predetermined finite cache*/
-        template <typename T, typename std::enable_if_t<std::is_integral<T>::value, bool> = true>
-        T cached_generator(T a, T b);
-
-        template <typename T, typename std::enable_if_t<!std::is_integral<T>::value, bool> = true>
+        template <typename T>
         T cached_generator(T a, T b);
 
         /*! \brief generate a random normally distributed number around 0 with stddev 1 from a predetermined finite cache */
@@ -101,55 +85,37 @@ namespace rocsparse
     };
 }
 
-/* ==================================================================================== */
-/* generate random number :*/
+/*
+* ===========================================================================
+*    Wrappers
+* ===========================================================================
+*/
 
 /*! \brief  generate a random number in range [a,b] using integer numbers*/
 template <typename T>
-inline T random_generator_exact(int a = 1, int b = 10)
-{
-    return rocsparse::rng_t::Instance().generator_exact<T>(a, b);
-}
+T random_generator_exact(int a = 1, int b = 10);
 
 /*! \brief  generate a random number in range [a,b]*/
 template <typename T, typename std::enable_if_t<std::is_integral<T>::value, bool> = true>
-inline T random_generator(T a = static_cast<T>(1), T b = static_cast<T>(10))
-{
-    return rocsparse::rng_t::Instance().generator<T>(a, b);
-}
+T random_generator(T a = static_cast<T>(1), T b = static_cast<T>(10));
 
 template <typename T, typename std::enable_if_t<!std::is_integral<T>::value, bool> = true>
-inline T random_generator(T a = static_cast<T>(0), T b = static_cast<T>(1))
-{
-    return rocsparse::rng_t::Instance().generator<T>(a, b);
-}
+T random_generator(T a = static_cast<T>(0), T b = static_cast<T>(1));
 
 /*! \brief  generate a random number in range [a,b] from a predetermined finite cache using integer numbers*/
 template <typename T>
-inline T random_cached_generator_exact(int a = 1, int b = 10)
-{
-    return rocsparse::rng_t::Instance().cached_generator_exact<T>(a, b);
-}
+T random_cached_generator_exact(int a = 1, int b = 10);
 
 /*! \brief  generate a random number in range [a,b] from a predetermined finite cache*/
 template <typename T, typename std::enable_if_t<std::is_integral<T>::value, bool> = true>
-inline T random_cached_generator(T a = static_cast<T>(1), T b = static_cast<T>(10))
-{
-    return rocsparse::rng_t::Instance().cached_generator<T>(a, b);
-}
+T random_cached_generator(T a = static_cast<T>(1), T b = static_cast<T>(10));
 
 template <typename T, typename std::enable_if_t<!std::is_integral<T>::value, bool> = true>
-inline T random_cached_generator(T a = static_cast<T>(0), T b = static_cast<T>(1))
-{
-    return rocsparse::rng_t::Instance().cached_generator<T>(a, b);
-}
+T random_cached_generator(T a = static_cast<T>(0), T b = static_cast<T>(1));
 
 /*! \brief generate a random normally distributed number around 0 with stddev 1 from a predetermined finite cache */
 template <typename T>
-inline T random_cached_generator_normal()
-{
-    return rocsparse::rng_t::Instance().cached_generator_normal<T>();
-}
+T random_cached_generator_normal();
 
 // Reset the seed (mainly to ensure repeatability of failures in a given suite)
 void rocsparse_seedrand();

--- a/clients/include/rocsparse_random.hpp
+++ b/clients/include/rocsparse_random.hpp
@@ -30,36 +30,156 @@
 
 #include <random>
 #include <type_traits>
-
-/* ==================================================================================== */
-// Random number generator
+#include <vector>
 
 using rocsparse_rng_t = std::mt19937;
 
-void rocsparse_rng_set(rocsparse_rng_t a);
+namespace rocsparse
+{
+    class random
+    {
+    private:
+        random();
+        ~random()                        = default;
+        random(const random&)            = delete;
+        random& operator=(const random&) = delete;
 
-void rocsparse_seed_set(rocsparse_rng_t a);
+        rocsparse_rng_t rng;
+        rocsparse_rng_t rng_nan;
+        rocsparse_rng_t rng_seed;
 
-void rocsparse_rng_nan_set(rocsparse_rng_t a);
+        int                 rand_uniform_idx;
+        int                 rand_normal_idx;
+        std::vector<double> rand_uniform_cache;
+        std::vector<double> rand_normal_cache;
 
-rocsparse_rng_t& rocsparse_rng_get();
+        float  uniform_float(float a, float b);
+        double uniform_double(double a, double b);
+        int    uniform_int(int a, int b);
+        double normal_double();
 
-rocsparse_rng_t& rocsparse_seed_get();
+    public:
+        static random& Instance()
+        {
+            static random instance;
+            return instance;
+        }
 
-rocsparse_rng_t& rocsparse_rng_nan_get();
+        void reset_seed()
+        {
+            rand_uniform_idx = 0;
+            rand_normal_idx  = 0;
 
-// extern  rocsparse_rng_t rocsparse_rng, rocsparse_seed, rocsparse_rng_nan;
+            rng_set(rng_seed);
+            rng_nan_set(rng_seed);
+        }
 
-extern int rocsparse_rand_uniform_idx;
-extern int rocsparse_rand_normal_idx;
+        void rng_set(rocsparse_rng_t a)
+        {
+            rng = a;
+        }
+        void rng_nan_set(rocsparse_rng_t a)
+        {
+            rng_nan = a;
+        }
+        void rng_seed_set(rocsparse_rng_t a)
+        {
+            rng_seed = a;
+        }
+
+        rocsparse_rng_t& rng_get()
+        {
+            return rng;
+        }
+        rocsparse_rng_t& rng_nan_get()
+        {
+            return rng_nan;
+        }
+        rocsparse_rng_t& rng_seed_get()
+        {
+            return rng_seed;
+        }
+
+        /*! \brief  generate a random number in range [a,b] using integer numbers*/
+        template <typename T>
+        T random_generator_exact(int a = 1, int b = 10);
+
+        /*! \brief  generate a random number in range [a,b]*/
+        template <typename T, typename std::enable_if_t<std::is_integral<T>::value, bool> = true>
+        T random_generator(T a = static_cast<T>(1), T b = static_cast<T>(10));
+
+        template <typename T, typename std::enable_if_t<!std::is_integral<T>::value, bool> = true>
+        T random_generator(T a = static_cast<T>(0), T b = static_cast<T>(1));
+
+        /*! \brief  generate a random number in range [a,b] from a predetermined finite cache using integer numbers*/
+        template <typename T>
+        T random_cached_generator_exact(int a = 1, int b = 10);
+
+        /*! \brief  generate a random number in range [a,b] from a predetermined finite cache*/
+        template <typename T, typename std::enable_if_t<std::is_integral<T>::value, bool> = true>
+        T random_cached_generator(T a = static_cast<T>(1), T b = static_cast<T>(10));
+
+        template <typename T, typename std::enable_if_t<!std::is_integral<T>::value, bool> = true>
+        T random_cached_generator(T a = static_cast<T>(0), T b = static_cast<T>(1));
+
+        /*! \brief generate a random normally distributed number around 0 with stddev 1 from a predetermined finite cache */
+        template <typename T>
+        T random_cached_generator_normal();
+    };
+}
+
+/* ==================================================================================== */
+/* generate random number :*/
+
+/*! \brief  generate a random number in range [a,b] using integer numbers*/
+template <typename T>
+inline T random_generator_exact(int a = 1, int b = 10)
+{
+    return rocsparse::random::Instance().random_generator_exact<T>(a, b);
+}
+
+/*! \brief  generate a random number in range [a,b]*/
+template <typename T, typename std::enable_if_t<std::is_integral<T>::value, bool> = true>
+inline T random_generator(T a = static_cast<T>(1), T b = static_cast<T>(10))
+{
+    return rocsparse::random::Instance().random_generator<T>(a, b);
+}
+
+template <typename T, typename std::enable_if_t<!std::is_integral<T>::value, bool> = true>
+inline T random_generator(T a = static_cast<T>(0), T b = static_cast<T>(1))
+{
+    return rocsparse::random::Instance().random_generator<T>(a, b);
+}
+
+/*! \brief  generate a random number in range [a,b] from a predetermined finite cache using integer numbers*/
+template <typename T>
+inline T random_cached_generator_exact(int a = 1, int b = 10)
+{
+    return rocsparse::random::Instance().random_cached_generator_exact<T>(a, b);
+}
+
+/*! \brief  generate a random number in range [a,b] from a predetermined finite cache*/
+template <typename T, typename std::enable_if_t<std::is_integral<T>::value, bool> = true>
+inline T random_cached_generator(T a = static_cast<T>(1), T b = static_cast<T>(10))
+{
+    return rocsparse::random::Instance().random_cached_generator<T>(a, b);
+}
+
+template <typename T, typename std::enable_if_t<!std::is_integral<T>::value, bool> = true>
+inline T random_cached_generator(T a = static_cast<T>(0), T b = static_cast<T>(1))
+{
+    return rocsparse::random::Instance().random_cached_generator<T>(a, b);
+}
+
+/*! \brief generate a random normally distributed number around 0 with stddev 1 from a predetermined finite cache */
+template <typename T>
+inline T random_cached_generator_normal()
+{
+    return rocsparse::random::Instance().random_cached_generator_normal<T>();
+}
 
 // Reset the seed (mainly to ensure repeatability of failures in a given suite)
 void rocsparse_seedrand();
-
-int    rocsparse_uniform_int(int a, int b);
-float  rocsparse_uniform_float(float a, float b);
-double rocsparse_uniform_double(double a, double b);
-double rocsparse_normal_double();
 
 /* ==================================================================================== */
 /*! \brief  Random number generator which generates NaN values */
@@ -77,7 +197,8 @@ class rocsparse_nan_rng
             T      fp;
         } x;
         do
-            x.u = std::uniform_int_distribution<UINT_T>{}(rocsparse_rng_nan_get());
+            x.u = std::uniform_int_distribution<UINT_T>{}(
+                rocsparse::random::Instance().rng_nan_get());
         while(!(x.u & (((UINT_T)1 << SIG) - 1))); // Reject Inf (mantissa == 0)
         x.u |= (((UINT_T)1 << EXP) - 1) << SIG; // Exponent = all 1's
         return x.fp; // NaN with random bits
@@ -88,7 +209,7 @@ public:
     template <typename T, typename std::enable_if<std::is_integral<T>{}, int>::type = 0>
     explicit operator T()
     {
-        return std::uniform_int_distribution<T>{}(rocsparse_rng_nan_get());
+        return std::uniform_int_distribution<T>{}(rocsparse::random::Instance().rng_nan_get());
     }
 
     // Random int8_t
@@ -96,7 +217,7 @@ public:
     {
         return (int8_t)std::uniform_int_distribution<int>(std::numeric_limits<int8_t>::min(),
                                                           std::numeric_limits<int8_t>::max())(
-            rocsparse_rng_nan_get());
+            rocsparse::random::Instance().rng_nan_get());
     }
 
     // Random char
@@ -104,7 +225,7 @@ public:
     {
         return (char)std::uniform_int_distribution<int>(std::numeric_limits<char>::min(),
                                                         std::numeric_limits<char>::max())(
-            rocsparse_rng_nan_get());
+            rocsparse::random::Instance().rng_nan_get());
     }
 
     // Random NaN half
@@ -141,145 +262,5 @@ public:
         return {double(*this), double(*this)};
     }
 };
-
-/* ==================================================================================== */
-/* generate random number :*/
-
-/*! \brief  generate a random number in range [a,b] using integer numbers*/
-template <typename T>
-inline T random_generator_exact(int a = 1, int b = 10)
-{
-    return std::uniform_int_distribution<int>(a, b)(rocsparse_rng_get());
-}
-
-template <>
-inline rocsparse_float_complex random_generator_exact<rocsparse_float_complex>(int a, int b)
-{
-    return rocsparse_float_complex(random_generator_exact<float>(a, b),
-                                   random_generator_exact<float>(a, b));
-}
-
-template <>
-inline rocsparse_double_complex random_generator_exact<rocsparse_double_complex>(int a, int b)
-{
-    return rocsparse_double_complex(random_generator_exact<double>(a, b),
-                                    random_generator_exact<double>(a, b));
-}
-
-/*! \brief  generate a random number in range [a,b]*/
-template <typename T, typename std::enable_if_t<std::is_integral<T>::value, bool> = true>
-inline T random_generator(T a = static_cast<T>(1), T b = static_cast<T>(10))
-{
-    return random_generator_exact<T>(a, b);
-}
-
-template <typename T, typename std::enable_if_t<!std::is_integral<T>::value, bool> = true>
-inline T random_generator(T a = static_cast<T>(0), T b = static_cast<T>(1))
-{
-    return std::uniform_real_distribution<T>(a, b)(rocsparse_rng_get());
-}
-
-template <>
-inline rocsparse_float_complex random_generator<rocsparse_float_complex>(rocsparse_float_complex a,
-                                                                         rocsparse_float_complex b)
-{
-    float theta = random_generator<float>(0.0f, 2.0f * acos(-1.0f));
-    float r     = random_generator<float>(std::abs(a), std::abs(b));
-
-    return rocsparse_float_complex(r * cos(theta), r * sin(theta));
-}
-
-template <>
-inline rocsparse_double_complex
-    random_generator<rocsparse_double_complex>(rocsparse_double_complex a,
-                                               rocsparse_double_complex b)
-{
-    double theta = random_generator<double>(0.0, 2.0 * acos(-1.0));
-    double r     = random_generator<double>(std::abs(a), std::abs(b));
-
-    return rocsparse_double_complex(r * cos(theta), r * sin(theta));
-}
-
-/*! \brief  generate a random number in range [a,b] from a predetermined finite cache using integer numbers*/
-template <typename T>
-inline T random_cached_generator_exact(int a = 1, int b = 10)
-{
-    return rocsparse_uniform_int(a, b);
-}
-
-template <>
-inline float random_cached_generator_exact(int a, int b)
-{
-    return static_cast<float>(rocsparse_uniform_int(a, b));
-}
-
-template <>
-inline double random_cached_generator_exact(int a, int b)
-{
-    return static_cast<double>(rocsparse_uniform_int(a, b));
-}
-
-template <>
-inline rocsparse_float_complex random_cached_generator_exact<rocsparse_float_complex>(int a, int b)
-{
-    return rocsparse_float_complex(random_cached_generator_exact<float>(a, b),
-                                   random_cached_generator_exact<float>(a, b));
-}
-
-template <>
-inline rocsparse_double_complex random_cached_generator_exact<rocsparse_double_complex>(int a,
-                                                                                        int b)
-{
-    return rocsparse_double_complex(random_cached_generator_exact<double>(a, b),
-                                    random_cached_generator_exact<double>(a, b));
-}
-
-/*! \brief  generate a random number in range [a,b] from a predetermined finite cache*/
-template <typename T, typename std::enable_if_t<std::is_integral<T>::value, bool> = true>
-inline T random_cached_generator(T a = static_cast<T>(1), T b = static_cast<T>(10))
-{
-    return random_cached_generator_exact<T>(a, b);
-}
-
-template <typename T, typename std::enable_if_t<!std::is_integral<T>::value, bool> = true>
-inline T random_cached_generator(T a = static_cast<T>(0), T b = static_cast<T>(1))
-{
-    return static_cast<T>(rocsparse_uniform_float(a, b));
-}
-
-template <>
-inline double random_cached_generator(double a, double b)
-{
-    return rocsparse_uniform_double(a, b);
-}
-
-template <>
-inline rocsparse_float_complex
-    random_cached_generator<rocsparse_float_complex>(rocsparse_float_complex a,
-                                                     rocsparse_float_complex b)
-{
-    float theta = random_cached_generator<float>(0.0f, 2.0f * acos(-1.0f));
-    float r     = random_cached_generator<float>(std::abs(a), std::abs(b));
-
-    return rocsparse_float_complex(r * cos(theta), r * sin(theta));
-}
-
-template <>
-inline rocsparse_double_complex
-    random_cached_generator<rocsparse_double_complex>(rocsparse_double_complex a,
-                                                      rocsparse_double_complex b)
-{
-    double theta = random_cached_generator<double>(0.0, 2.0 * acos(-1.0));
-    double r     = random_cached_generator<double>(std::abs(a), std::abs(b));
-
-    return rocsparse_double_complex(r * cos(theta), r * sin(theta));
-}
-
-/*! \brief generate a random normally distributed number around 0 with stddev 1 from a predetermined finite cache */
-template <typename T>
-inline T random_cached_generator_normal()
-{
-    return static_cast<T>(rocsparse_normal_double());
-}
 
 #endif // ROCSPARSE_RANDOM_HPP

--- a/clients/include/rocsparse_random.hpp
+++ b/clients/include/rocsparse_random.hpp
@@ -46,15 +46,15 @@ namespace rocsparse
         rocsparse_rng_t m_rng_nan;
         rocsparse_rng_t m_rng_seed;
 
-        int                 m_rand_uniform_idx;
-        int                 m_rand_normal_idx;
+        int32_t             m_rand_uniform_idx;
+        int32_t             m_rand_normal_idx;
         std::vector<double> m_rand_uniform_cache;
         std::vector<double> m_rand_normal_cache;
 
-        float  uniform_float(float a, float b);
-        double uniform_double(double a, double b);
-        int    uniform_int(int a, int b);
-        double normal_double();
+        float   uniform_float(float a, float b);
+        double  uniform_double(double a, double b);
+        int32_t uniform_int(int32_t a, int32_t b);
+        double  normal_double();
 
     public:
         static rng_t& Instance()
@@ -63,62 +63,37 @@ namespace rocsparse
             return instance;
         }
 
-        void reset_seed()
-        {
-            m_rand_uniform_idx = 0;
-            m_rand_normal_idx  = 0;
+        void reset_seed();
 
-            set_rng(m_rng_seed);
-            set_rng_nan(m_rng_seed);
-        }
+        void set_rng(rocsparse_rng_t a);
+        void set_rng_nan(rocsparse_rng_t a);
+        void rng_seed_set(rocsparse_rng_t a);
 
-        void set_rng(rocsparse_rng_t a)
-        {
-            m_rng = a;
-        }
-        void set_rng_nan(rocsparse_rng_t a)
-        {
-            m_rng_nan = a;
-        }
-        void rng_seed_set(rocsparse_rng_t a)
-        {
-            m_rng_seed = a;
-        }
-
-        rocsparse_rng_t& get_rng()
-        {
-            return m_rng;
-        }
-        rocsparse_rng_t& get_rng_nan()
-        {
-            return m_rng_nan;
-        }
-        rocsparse_rng_t& get_rng_seed()
-        {
-            return m_rng_seed;
-        }
+        rocsparse_rng_t& get_rng();
+        rocsparse_rng_t& get_rng_nan();
+        rocsparse_rng_t& get_rng_seed();
 
         /*! \brief  generate a random number in range [a,b] using integer numbers*/
         template <typename T>
-        T generator_exact(int a = 1, int b = 10);
+        T generator_exact(int32_t a, int32_t b);
 
         /*! \brief  generate a random number in range [a,b]*/
         template <typename T, typename std::enable_if_t<std::is_integral<T>::value, bool> = true>
-        T generator(T a = static_cast<T>(1), T b = static_cast<T>(10));
+        T generator(T a, T b);
 
         template <typename T, typename std::enable_if_t<!std::is_integral<T>::value, bool> = true>
-        T generator(T a = static_cast<T>(0), T b = static_cast<T>(1));
+        T generator(T a, T b);
 
         /*! \brief  generate a random number in range [a,b] from a predetermined finite cache using integer numbers*/
         template <typename T>
-        T cached_generator_exact(int a = 1, int b = 10);
+        T cached_generator_exact(int32_t a, int32_t b);
 
         /*! \brief  generate a random number in range [a,b] from a predetermined finite cache*/
         template <typename T, typename std::enable_if_t<std::is_integral<T>::value, bool> = true>
-        T cached_generator(T a = static_cast<T>(1), T b = static_cast<T>(10));
+        T cached_generator(T a, T b);
 
         template <typename T, typename std::enable_if_t<!std::is_integral<T>::value, bool> = true>
-        T cached_generator(T a = static_cast<T>(0), T b = static_cast<T>(1));
+        T cached_generator(T a, T b);
 
         /*! \brief generate a random normally distributed number around 0 with stddev 1 from a predetermined finite cache */
         template <typename T>

--- a/clients/include/rocsparse_random.hpp
+++ b/clients/include/rocsparse_random.hpp
@@ -23,8 +23,6 @@
  * ************************************************************************ */
 
 #pragma once
-#ifndef ROCSPARSE_RANDOM_HPP
-#define ROCSPARSE_RANDOM_HPP
 
 #include "rocsparse_math.hpp"
 
@@ -36,22 +34,22 @@ using rocsparse_rng_t = std::mt19937;
 
 namespace rocsparse
 {
-    class random
+    class rng_t
     {
     private:
-        random();
-        ~random()                        = default;
-        random(const random&)            = delete;
-        random& operator=(const random&) = delete;
+        rng_t();
+        ~rng_t()                       = default;
+        rng_t(const rng_t&)            = delete;
+        rng_t& operator=(const rng_t&) = delete;
 
-        rocsparse_rng_t rng;
-        rocsparse_rng_t rng_nan;
-        rocsparse_rng_t rng_seed;
+        rocsparse_rng_t m_rng;
+        rocsparse_rng_t m_rng_nan;
+        rocsparse_rng_t m_rng_seed;
 
-        int                 rand_uniform_idx;
-        int                 rand_normal_idx;
-        std::vector<double> rand_uniform_cache;
-        std::vector<double> rand_normal_cache;
+        int                 m_rand_uniform_idx;
+        int                 m_rand_normal_idx;
+        std::vector<double> m_rand_uniform_cache;
+        std::vector<double> m_rand_normal_cache;
 
         float  uniform_float(float a, float b);
         double uniform_double(double a, double b);
@@ -59,72 +57,72 @@ namespace rocsparse
         double normal_double();
 
     public:
-        static random& Instance()
+        static rng_t& Instance()
         {
-            static random instance;
+            static rng_t instance;
             return instance;
         }
 
         void reset_seed()
         {
-            rand_uniform_idx = 0;
-            rand_normal_idx  = 0;
+            m_rand_uniform_idx = 0;
+            m_rand_normal_idx  = 0;
 
-            rng_set(rng_seed);
-            rng_nan_set(rng_seed);
+            set_rng(m_rng_seed);
+            set_rng_nan(m_rng_seed);
         }
 
-        void rng_set(rocsparse_rng_t a)
+        void set_rng(rocsparse_rng_t a)
         {
-            rng = a;
+            m_rng = a;
         }
-        void rng_nan_set(rocsparse_rng_t a)
+        void set_rng_nan(rocsparse_rng_t a)
         {
-            rng_nan = a;
+            m_rng_nan = a;
         }
         void rng_seed_set(rocsparse_rng_t a)
         {
-            rng_seed = a;
+            m_rng_seed = a;
         }
 
-        rocsparse_rng_t& rng_get()
+        rocsparse_rng_t& get_rng()
         {
-            return rng;
+            return m_rng;
         }
-        rocsparse_rng_t& rng_nan_get()
+        rocsparse_rng_t& get_rng_nan()
         {
-            return rng_nan;
+            return m_rng_nan;
         }
-        rocsparse_rng_t& rng_seed_get()
+        rocsparse_rng_t& get_rng_seed()
         {
-            return rng_seed;
+            return m_rng_seed;
         }
 
         /*! \brief  generate a random number in range [a,b] using integer numbers*/
         template <typename T>
-        T random_generator_exact(int a = 1, int b = 10);
+        T generator_exact(int a = 1, int b = 10);
 
         /*! \brief  generate a random number in range [a,b]*/
         template <typename T, typename std::enable_if_t<std::is_integral<T>::value, bool> = true>
-        T random_generator(T a = static_cast<T>(1), T b = static_cast<T>(10));
+        T generator(T a = static_cast<T>(1), T b = static_cast<T>(10));
 
         template <typename T, typename std::enable_if_t<!std::is_integral<T>::value, bool> = true>
-        T random_generator(T a = static_cast<T>(0), T b = static_cast<T>(1));
+        T generator(T a = static_cast<T>(0), T b = static_cast<T>(1));
 
         /*! \brief  generate a random number in range [a,b] from a predetermined finite cache using integer numbers*/
         template <typename T>
-        T random_cached_generator_exact(int a = 1, int b = 10);
+        T cached_generator_exact(int a = 1, int b = 10);
 
         /*! \brief  generate a random number in range [a,b] from a predetermined finite cache*/
         template <typename T, typename std::enable_if_t<std::is_integral<T>::value, bool> = true>
-        T random_cached_generator(T a = static_cast<T>(1), T b = static_cast<T>(10));
+        T cached_generator(T a = static_cast<T>(1), T b = static_cast<T>(10));
 
         template <typename T, typename std::enable_if_t<!std::is_integral<T>::value, bool> = true>
-        T random_cached_generator(T a = static_cast<T>(0), T b = static_cast<T>(1));
+        T cached_generator(T a = static_cast<T>(0), T b = static_cast<T>(1));
 
         /*! \brief generate a random normally distributed number around 0 with stddev 1 from a predetermined finite cache */
         template <typename T>
-        T random_cached_generator_normal();
+        T cached_generator_normal();
     };
 }
 
@@ -135,47 +133,47 @@ namespace rocsparse
 template <typename T>
 inline T random_generator_exact(int a = 1, int b = 10)
 {
-    return rocsparse::random::Instance().random_generator_exact<T>(a, b);
+    return rocsparse::rng_t::Instance().generator_exact<T>(a, b);
 }
 
 /*! \brief  generate a random number in range [a,b]*/
 template <typename T, typename std::enable_if_t<std::is_integral<T>::value, bool> = true>
 inline T random_generator(T a = static_cast<T>(1), T b = static_cast<T>(10))
 {
-    return rocsparse::random::Instance().random_generator<T>(a, b);
+    return rocsparse::rng_t::Instance().generator<T>(a, b);
 }
 
 template <typename T, typename std::enable_if_t<!std::is_integral<T>::value, bool> = true>
 inline T random_generator(T a = static_cast<T>(0), T b = static_cast<T>(1))
 {
-    return rocsparse::random::Instance().random_generator<T>(a, b);
+    return rocsparse::rng_t::Instance().generator<T>(a, b);
 }
 
 /*! \brief  generate a random number in range [a,b] from a predetermined finite cache using integer numbers*/
 template <typename T>
 inline T random_cached_generator_exact(int a = 1, int b = 10)
 {
-    return rocsparse::random::Instance().random_cached_generator_exact<T>(a, b);
+    return rocsparse::rng_t::Instance().cached_generator_exact<T>(a, b);
 }
 
 /*! \brief  generate a random number in range [a,b] from a predetermined finite cache*/
 template <typename T, typename std::enable_if_t<std::is_integral<T>::value, bool> = true>
 inline T random_cached_generator(T a = static_cast<T>(1), T b = static_cast<T>(10))
 {
-    return rocsparse::random::Instance().random_cached_generator<T>(a, b);
+    return rocsparse::rng_t::Instance().cached_generator<T>(a, b);
 }
 
 template <typename T, typename std::enable_if_t<!std::is_integral<T>::value, bool> = true>
 inline T random_cached_generator(T a = static_cast<T>(0), T b = static_cast<T>(1))
 {
-    return rocsparse::random::Instance().random_cached_generator<T>(a, b);
+    return rocsparse::rng_t::Instance().cached_generator<T>(a, b);
 }
 
 /*! \brief generate a random normally distributed number around 0 with stddev 1 from a predetermined finite cache */
 template <typename T>
 inline T random_cached_generator_normal()
 {
-    return rocsparse::random::Instance().random_cached_generator_normal<T>();
+    return rocsparse::rng_t::Instance().cached_generator_normal<T>();
 }
 
 // Reset the seed (mainly to ensure repeatability of failures in a given suite)
@@ -198,7 +196,7 @@ class rocsparse_nan_rng
         } x;
         do
             x.u = std::uniform_int_distribution<UINT_T>{}(
-                rocsparse::random::Instance().rng_nan_get());
+                rocsparse::rng_t::Instance().get_rng_nan());
         while(!(x.u & (((UINT_T)1 << SIG) - 1))); // Reject Inf (mantissa == 0)
         x.u |= (((UINT_T)1 << EXP) - 1) << SIG; // Exponent = all 1's
         return x.fp; // NaN with random bits
@@ -209,7 +207,7 @@ public:
     template <typename T, typename std::enable_if<std::is_integral<T>{}, int>::type = 0>
     explicit operator T()
     {
-        return std::uniform_int_distribution<T>{}(rocsparse::random::Instance().rng_nan_get());
+        return std::uniform_int_distribution<T>{}(rocsparse::rng_t::Instance().get_rng_nan());
     }
 
     // Random int8_t
@@ -217,7 +215,7 @@ public:
     {
         return (int8_t)std::uniform_int_distribution<int>(std::numeric_limits<int8_t>::min(),
                                                           std::numeric_limits<int8_t>::max())(
-            rocsparse::random::Instance().rng_nan_get());
+            rocsparse::rng_t::Instance().get_rng_nan());
     }
 
     // Random char
@@ -225,7 +223,7 @@ public:
     {
         return (char)std::uniform_int_distribution<int>(std::numeric_limits<char>::min(),
                                                         std::numeric_limits<char>::max())(
-            rocsparse::random::Instance().rng_nan_get());
+            rocsparse::rng_t::Instance().get_rng_nan());
     }
 
     // Random NaN half
@@ -262,5 +260,3 @@ public:
         return {double(*this), double(*this)};
     }
 };
-
-#endif // ROCSPARSE_RANDOM_HPP


### PR DESCRIPTION
Summary of proposed changes:
- We generate random numbers both "on the fly" by directly calling `std::uniform_real_distribution` and `std::uniform_int_distribution`, and also by generating a cache of random numbers up front.
- Both generating the numbers "on the fly" and generating them for the cache all use the same random number generator
- Currently the cache of random numbers if filled the first time we ask for a random number from this cache from any test. It is only filled once.
- Because we use the same generator for generating numbers "on the fly" and for the cache, this has the unfortunate consequence that the order in which you ask for random numbers matters.
- For example, if I ask for a dynamic "on the fly" random number that calls  `std::uniform_real_distribution` followed by asking for a cached random number, the numbers returned will be different then if I had asked for the cached random number first followed by the dynamic "on the fly" random number.
- It also has the consequence that if you use `--gtest_repeat=10`, the matrix data in the first run will be different from the data in the 2, 3, 4, ...10 (where the data for all runs 2, 3, 4,...10 is the SAME not different).
- The solution to all of this is, instead of generating the random number caches the first time a cached random number is asked for, we instead generate these caches the first time ANY random number is asked for. I achieve this using a singleton class where the random number caches are filled in the private constructor.
