### PR TITLE
clients: Fix envvar name for TEST_DATA_DIR

### DIFF
--- a/clients/common/rocsparse_clients_envariables.cpp
+++ b/clients/common/rocsparse_clients_envariables.cpp
@@ -44,7 +44,7 @@ static constexpr const char* s_var_bool_names[s_var_bool_size]
        "ROCSPARSE_CLIENTS_TEST_DEBUG_ARGUMENTS",
        "ROCSPARSE_CLIENTS_ROCTX"};
 static constexpr const char* s_var_string_names[s_var_string_size]
-    = {"ROCSPARSE_CLIENTS_MATRICES_DIR", "ROCSPARSE_TEST_DATA"};
+    = {"ROCSPARSE_CLIENTS_MATRICES_DIR", "ROCSPARSE_CLIENTS_TEST_DATA_DIR"};
 static constexpr const char* s_var_bool_descriptions[s_var_bool_size]
     = {"0: disabled, 1: enabled", "0: disabled, 1: enabled"};
 static constexpr const char* s_var_string_descriptions[s_var_string_size]


### PR DESCRIPTION
To override the test data path, one needs to set `TEST_DATA_DIR`, which will be prepended with `ROCSPARSE_CLIENTS_`.

So the correct name is `ROCSPARSE_CLIENTS_TEST_DATA_DIR`. This can be seen from the `MATRICES_DIR` entry.

In my tests, this restored the ability to override the path.

resolves #527