### PR TITLE
Remove bad_args checks from valid arguments section of the testing

### DIFF
--- a/clients/tests/test_coo2dense.yaml
+++ b/clients/tests/test_coo2dense.yaml
@@ -37,7 +37,7 @@ Tests:
   precision: *single_double_precisions_complex_real
   M: [0, 3, 8, 13, 64, 256]
   N: [0, 3, 8, 13, 64, 256]
-  denseld: [64, 512]
+  denseld: [256, 512]
   baseA: [rocsparse_index_base_zero, rocsparse_index_base_one]
   storage: [rocsparse_storage_mode_sorted, rocsparse_storage_mode_unsorted]
 
@@ -47,7 +47,7 @@ Tests:
   precision: *single_double_precisions_complex_real
   M: [0, 531, 1000]
   N: [0, 241, 1000]
-  denseld: [100, 1000, 2000]
+  denseld: [1000, 2000]
   baseA: [rocsparse_index_base_zero, rocsparse_index_base_one]
   storage: [rocsparse_storage_mode_sorted, rocsparse_storage_mode_unsorted]
 
@@ -57,7 +57,7 @@ Tests:
   precision: *single_double_precisions_complex_real
   M: [0, 531, 1000]
   N: [0, 241, 1000]
-  denseld: [100, 1000, 2000]
+  denseld: [1000, 2000]
   baseA: [rocsparse_index_base_zero, rocsparse_index_base_one]
   storage: [rocsparse_storage_mode_sorted, rocsparse_storage_mode_unsorted]
   graph_test: true

--- a/clients/tests/test_csc2dense.yaml
+++ b/clients/tests/test_csc2dense.yaml
@@ -37,7 +37,7 @@ Tests:
   precision: *single_double_precisions_complex_real
   M: [0, 3, 8, 13, 64, 256]
   N: [0, 3, 8, 13, 64, 256]
-  denseld: [-8, 64, 512]
+  denseld: [256, 512]
   baseA: [rocsparse_index_base_zero, rocsparse_index_base_one]
 
 - name: csc2dense
@@ -46,7 +46,7 @@ Tests:
   precision: *single_double_precisions_complex_real
   M: [0, 531, 1000]
   N: [0, 241, 1000]
-  denseld: [100, 1000, 2000]
+  denseld: [1000, 2000]
   baseA: [rocsparse_index_base_zero, rocsparse_index_base_one]
 
 - name: csc2dense
@@ -55,7 +55,7 @@ Tests:
   precision: *single_double_precisions_complex_real
   M: [0, 531, 1000]
   N: [0, 241, 1000]
-  denseld: [100, 1000, 2000]
+  denseld: [1000, 2000]
   baseA: [rocsparse_index_base_zero, rocsparse_index_base_one]
   graph_test: true
 

--- a/clients/tests/test_csr2dense.yaml
+++ b/clients/tests/test_csr2dense.yaml
@@ -37,7 +37,7 @@ Tests:
   precision: *single_double_precisions_complex_real
   M: [0, 3, 8, 13, 64, 256]
   N: [0, 3, 8, 13, 64, 256]
-  denseld: [-8, 64, 512]
+  denseld: [256, 512]
   baseA: [rocsparse_index_base_zero, rocsparse_index_base_one]
 
 - name: csr2dense
@@ -46,7 +46,7 @@ Tests:
   precision: *single_double_precisions_complex_real
   M: [0, 531, 1000]
   N: [0, 241, 1000]
-  denseld: [100, 1000, 2000]
+  denseld: [1000, 2000]
   baseA: [rocsparse_index_base_zero, rocsparse_index_base_one]
 
 - name: csr2dense
@@ -55,7 +55,7 @@ Tests:
   precision: *single_double_precisions_complex_real
   M: [0, 531, 1000]
   N: [0, 241, 1000]
-  denseld: [100, 1000, 2000]
+  denseld: [1000, 2000]
   baseA: [rocsparse_index_base_zero, rocsparse_index_base_one]
   graph_test: true
 

--- a/clients/tests/test_csrgemm.yaml
+++ b/clients/tests/test_csrgemm.yaml
@@ -65,7 +65,7 @@ Tests:
   precision: *single_double_precisions_complex_real
   M: [50]
   N: [13]
-  K: [-1, 50]
+  K: [50]
   alpha_alphai: *alpha_range_quick
   beta: [-99.0]
   transA: [rocsparse_operation_none]
@@ -95,9 +95,9 @@ Tests:
   category: pre_checkin
   function: csrgemm
   precision: *single_double_precisions_complex_real
-  M: [-1, 0, 1799, 32519]
-  N: [-1, 0, 3712, 16021]
-  K: [-1, 0, 1942, 9848]
+  M: [0, 1799, 32519]
+  N: [0, 3712, 16021]
+  K: [0, 1942, 9848]
   alpha_alphai: *alpha_range_checkin
   beta: [-99.0]
   transA: [rocsparse_operation_none]
@@ -149,7 +149,7 @@ Tests:
   function: csrgemm
   precision: *single_double_precisions
   M: 1
-  N: [-1, 0, 3712, 16021]
+  N: [0, 3712, 16021]
   K: 1
   alpha_alphai: *alpha_range_checkin
   beta: [-99.0]
@@ -229,7 +229,7 @@ Tests:
   function: csrgemm
   precision: *single_double_precisions_complex
   M: 1
-  N: [-1, 0, 5925, 20142]
+  N: [0, 5925, 20142]
   K: 1
   alpha_alphai: *alpha_range_checkin
   beta: [-99.0]
@@ -277,8 +277,8 @@ Tests:
   category: quick
   function: csrgemm
   precision: *single_double_precisions_complex_real
-  M: [-1, 0, 8, 24, 582]
-  N: [-1, 0, 12, 48, 243]
+  M: [0, 8, 24, 582]
+  N: [0, 12, 48, 243]
   K: 1
   alpha: [-99.0]
   beta_betai: *beta_range_quick
@@ -290,8 +290,8 @@ Tests:
   category: pre_checkin
   function: csrgemm
   precision: *single_double_precisions_complex_real
-  M: [-1, 0, 932, 1523, 23404]
-  N: [-1, 0, 784, 4842, 19703]
+  M: [0, 932, 1523, 23404]
+  N: [0, 784, 4842, 19703]
   K: 1
   alpha: [-99.0]
   beta_betai: *beta_range_checkin

--- a/clients/tests/test_prune_dense2csr.yaml
+++ b/clients/tests/test_prune_dense2csr.yaml
@@ -37,7 +37,7 @@ Tests:
   precision: *single_double_precisions
   M: [3, 8, 13, 64, 256]
   N: [3, 8, 13, 64, 256]
-  denseld: [-8, 64, 512]
+  denseld: [256, 512]
   threshold: [0.1, 0.5, 1.2]
   baseA: [rocsparse_index_base_zero, rocsparse_index_base_one]
 
@@ -47,7 +47,7 @@ Tests:
   precision: *single_double_precisions
   M: [531, 1000]
   N: [241, 1000]
-  denseld: [100, 1000, 2000]
+  denseld: [1000, 2000]
   threshold: [0.5, 0.0, 0.9, 0.001]
   baseA: [rocsparse_index_base_zero, rocsparse_index_base_one]
 
@@ -77,7 +77,7 @@ Tests:
   precision: *single_double_precisions
   M: [500, 872]
   N: [242, 623]
-  denseld: [500]
+  denseld: [900]
   threshold: [0.67, 0.003, 0.75, 0.999]
   baseA: [rocsparse_index_base_zero, rocsparse_index_base_one]
 

--- a/clients/tests/test_prune_dense2csr_by_percentage.yaml
+++ b/clients/tests/test_prune_dense2csr_by_percentage.yaml
@@ -37,7 +37,7 @@ Tests:
   precision: *single_double_precisions
   M: [3, 8, 13, 64, 256]
   N: [3, 8, 13, 64, 256]
-  denseld: [-8, 64, 512]
+  denseld: [256, 512]
   percentage: [0.0, 10.0, 20.0, 50.0, 100.0]
   baseA: [rocsparse_index_base_zero, rocsparse_index_base_one]
 
@@ -47,7 +47,7 @@ Tests:
   precision: *single_double_precisions
   M: [531, 1000]
   N: [241, 1000]
-  denseld: [100, 1000, 2000]
+  denseld: [1000, 2000]
   percentage: [0.1, 33.0, 100.0]
   baseA: [rocsparse_index_base_zero, rocsparse_index_base_one]
 
@@ -77,7 +77,7 @@ Tests:
   precision: *single_double_precisions
   M: [500, 872]
   N: [242, 623]
-  denseld: [500]
+  denseld: [900]
   percentage: [0.0, 55.0]
   baseA: [rocsparse_index_base_zero, rocsparse_index_base_one]
 


### PR DESCRIPTION
Summary of proposed changes:
- Remove bad_args checks from valid arguments section of the testing as these bad argument checks are covered in there own section of the testing
- Further reduces the log spam that occurs when we hit an invalid status return code
