### PR TITLE
Use rocsparse::shfl instead of __shfl

### DIFF
--- a/library/src/conversion/csr2bsr_device.h
+++ b/library/src/conversion/csr2bsr_device.h
@@ -117,7 +117,7 @@ namespace rocsparse
             __threadfence_block();
 
             rocsparse::wfreduce_min<(WFSIZE / BLOCKDIM)>(&index_k);
-            next_k = __shfl(index_k, (WFSIZE / BLOCKDIM) - 1, (WFSIZE / BLOCKDIM));
+            next_k = rocsparse::shfl(index_k, (WFSIZE / BLOCKDIM) - 1, (WFSIZE / BLOCKDIM));
 
             int offset = 0;
             if(table[wid])
@@ -151,7 +151,7 @@ namespace rocsparse
             block_row_begin += offset;
 
             rocsparse::wfreduce_min<WFSIZE>(&min_block_col);
-            chunk_begin = __shfl(min_block_col, WFSIZE - 1, WFSIZE);
+            chunk_begin = rocsparse::shfl(min_block_col, WFSIZE - 1, WFSIZE);
 
             __threadfence_block();
         }
@@ -237,7 +237,7 @@ namespace rocsparse
             __syncthreads();
 
             rocsparse::wfreduce_min<BLOCKSIZE / BLOCKDIM>(&index_k);
-            next_k = __shfl(index_k, (BLOCKSIZE / BLOCKDIM) - 1, BLOCKSIZE / BLOCKDIM);
+            next_k = rocsparse::shfl(index_k, (BLOCKSIZE / BLOCKDIM) - 1, BLOCKSIZE / BLOCKDIM);
 
             int offset = 0;
             if(table)
@@ -389,10 +389,10 @@ namespace rocsparse
             }
 
             // broadcast CSR minimum column index from last thread in segment to all threads in segment
-            min_csr_col_index = __shfl(min_csr_col_index, BLOCKSIZE - 1, BLOCKSIZE);
+            min_csr_col_index = rocsparse::shfl(min_csr_col_index, BLOCKSIZE - 1, BLOCKSIZE);
 
             // broadcast nnzb_per_row from last thread in segment to all threads in segment
-            nnzb_per_row = __shfl(nnzb_per_row, BLOCKSIZE - 1, BLOCKSIZE);
+            nnzb_per_row = rocsparse::shfl(nnzb_per_row, BLOCKSIZE - 1, BLOCKSIZE);
 
             // Write BSR values
             for(J j = 0; j < rows_per_segment; j++)

--- a/library/src/conversion/csr2bsr_nnz_device.h
+++ b/library/src/conversion/csr2bsr_nnz_device.h
@@ -103,7 +103,7 @@ namespace rocsparse
             __threadfence_block();
 
             rocsparse::wfreduce_min<(WFSIZE / BLOCKDIM)>(&index_k);
-            next_k = __shfl(index_k, (WFSIZE / BLOCKDIM) - 1, (WFSIZE / BLOCKDIM));
+            next_k = rocsparse::shfl(index_k, (WFSIZE / BLOCKDIM) - 1, (WFSIZE / BLOCKDIM));
 
             if(found[wid] && lid == 0)
             {
@@ -111,7 +111,7 @@ namespace rocsparse
             }
 
             rocsparse::wfreduce_min<WFSIZE>(&min_block_col);
-            chunk_begin = __shfl(min_block_col, WFSIZE - 1, WFSIZE);
+            chunk_begin = rocsparse::shfl(min_block_col, WFSIZE - 1, WFSIZE);
 
             __threadfence_block();
         }
@@ -197,7 +197,7 @@ namespace rocsparse
             __syncthreads();
 
             rocsparse::wfreduce_min<BLOCKSIZE / BLOCKDIM>(&index_k);
-            next_k = __shfl(index_k, (BLOCKSIZE / BLOCKDIM) - 1, BLOCKSIZE / BLOCKDIM);
+            next_k = rocsparse::shfl(index_k, (BLOCKSIZE / BLOCKDIM) - 1, BLOCKSIZE / BLOCKDIM);
 
             if(found && tid == 0)
             {
@@ -290,7 +290,7 @@ namespace rocsparse
             rocsparse::wfreduce_min<BLOCKSIZE>(&min_block_col_index);
 
             // broadcast min_block_col_index from last thread in segment to all threads in segment
-            min_block_col_index = __shfl(min_block_col_index, BLOCKSIZE - 1, BLOCKSIZE);
+            min_block_col_index = rocsparse::shfl(min_block_col_index, BLOCKSIZE - 1, BLOCKSIZE);
 
             block_col = min_block_col_index + 1;
 

--- a/library/src/conversion/csr2csr_compress_device.h
+++ b/library/src/conversion/csr2csr_compress_device.h
@@ -228,7 +228,7 @@ namespace rocsparse
                 // Broadcast the update of the start_C to all threads in the seegment. Choose the last
                 // segment lane since that it contains the number of entries in the compressed sparse
                 // row (even if its predicate is false).
-                start_C += __shfl(
+                start_C += rocsparse::shfl(
                     static_cast<int>(count_previous_nnzs), SEGMENT_SIZE - 1, SEGMENT_SIZE);
             }
         }

--- a/library/src/conversion/csr2gebsr_device.h
+++ b/library/src/conversion/csr2gebsr_device.h
@@ -105,7 +105,7 @@ namespace rocsparse
             __threadfence_block();
 
             rocsparse::wfreduce_min<WFSIZE / ROW_BLOCKDIM>(&index_k);
-            next_k = __shfl(index_k, WFSIZE / ROW_BLOCKDIM - 1, WFSIZE / ROW_BLOCKDIM);
+            next_k = rocsparse::shfl(index_k, WFSIZE / ROW_BLOCKDIM - 1, WFSIZE / ROW_BLOCKDIM);
 
             if(found[wid] && lid == 0)
             {
@@ -113,7 +113,7 @@ namespace rocsparse
             }
 
             rocsparse::wfreduce_min<WFSIZE>(&min_block_col);
-            chunk_begin = __shfl(min_block_col, WFSIZE - 1, WFSIZE);
+            chunk_begin = rocsparse::shfl(min_block_col, WFSIZE - 1, WFSIZE);
 
             __threadfence_block();
         }
@@ -202,7 +202,8 @@ namespace rocsparse
             __syncthreads();
 
             rocsparse::wfreduce_min<BLOCKSIZE / ROW_BLOCKDIM>(&index_k);
-            next_k = __shfl(index_k, (BLOCKSIZE / ROW_BLOCKDIM) - 1, BLOCKSIZE / ROW_BLOCKDIM);
+            next_k = rocsparse::shfl(
+                index_k, (BLOCKSIZE / ROW_BLOCKDIM) - 1, BLOCKSIZE / ROW_BLOCKDIM);
 
             if(found && tid == 0)
             {
@@ -298,7 +299,7 @@ namespace rocsparse
             //
             // broadcast min_block_col_index from last thread in segment to all threads in segment
             //
-            min_block_col_index = __shfl(min_block_col_index, BLOCKSIZE - 1, BLOCKSIZE);
+            min_block_col_index = rocsparse::shfl(min_block_col_index, BLOCKSIZE - 1, BLOCKSIZE);
 
             block_col = min_block_col_index + 1;
 
@@ -410,7 +411,7 @@ namespace rocsparse
             __threadfence_block();
 
             rocsparse::wfreduce_min<WFSIZE / ROW_BLOCKDIM>(&index_k);
-            next_k = __shfl(index_k, (WFSIZE / ROW_BLOCKDIM) - 1, WFSIZE / ROW_BLOCKDIM);
+            next_k = rocsparse::shfl(index_k, (WFSIZE / ROW_BLOCKDIM) - 1, WFSIZE / ROW_BLOCKDIM);
 
             int offset = 0;
             if(table[wid])
@@ -446,7 +447,7 @@ namespace rocsparse
             block_row_begin += offset;
 
             rocsparse::wfreduce_min<WFSIZE>(&min_block_col);
-            chunk_begin = __shfl(min_block_col, WFSIZE - 1, WFSIZE);
+            chunk_begin = rocsparse::shfl(min_block_col, WFSIZE - 1, WFSIZE);
 
             __threadfence_block();
         }
@@ -535,7 +536,8 @@ namespace rocsparse
             __syncthreads();
 
             rocsparse::wfreduce_min<BLOCKSIZE / ROW_BLOCKDIM>(&index_k);
-            next_k = __shfl(index_k, (BLOCKSIZE / ROW_BLOCKDIM) - 1, BLOCKSIZE / ROW_BLOCKDIM);
+            next_k = rocsparse::shfl(
+                index_k, (BLOCKSIZE / ROW_BLOCKDIM) - 1, BLOCKSIZE / ROW_BLOCKDIM);
 
             int offset = 0;
             if(table)
@@ -687,10 +689,10 @@ namespace rocsparse
             }
 
             // broadcast CSR minimum column index from last thread in segment to all threads in segment
-            min_csr_col_index = __shfl(min_csr_col_index, BLOCKSIZE - 1, BLOCKSIZE);
+            min_csr_col_index = rocsparse::shfl(min_csr_col_index, BLOCKSIZE - 1, BLOCKSIZE);
 
             // broadcast nnzb_per_row from last thread in segment to all threads in segment
-            nnzb_per_row = __shfl(nnzb_per_row, BLOCKSIZE - 1, BLOCKSIZE);
+            nnzb_per_row = rocsparse::shfl(nnzb_per_row, BLOCKSIZE - 1, BLOCKSIZE);
 
             // Write BSR values
             for(rocsparse_int j = 0; j < rows_per_segment; j++)

--- a/library/src/conversion/gebsr2gebsr_device.h
+++ b/library/src/conversion/gebsr2gebsr_device.h
@@ -100,7 +100,8 @@ namespace rocsparse
             rocsparse::wfreduce_min<WF_SEGMENT_SIZE>(&min_block_col_index);
 
             // broadcast min_block_col_index from last thread in segment to all threads in segment
-            min_block_col_index = __shfl(min_block_col_index, WF_SEGMENT_SIZE - 1, WF_SEGMENT_SIZE);
+            min_block_col_index
+                = rocsparse::shfl(min_block_col_index, WF_SEGMENT_SIZE - 1, WF_SEGMENT_SIZE);
 
             // update block_col for all threads in segment
             block_col = min_block_col_index + 1;
@@ -211,10 +212,10 @@ namespace rocsparse
             }
 
             // broadcast CSR minimum column index from last thread in segment to all threads in segment
-            min_block_col = __shfl(min_block_col, WF_SEGMENT_SIZE - 1, WF_SEGMENT_SIZE);
+            min_block_col = rocsparse::shfl(min_block_col, WF_SEGMENT_SIZE - 1, WF_SEGMENT_SIZE);
 
             // broadcast nnzb_per_row from last thread in segment to all threads in segment
-            nnzb_per_row = __shfl(nnzb_per_row, WF_SEGMENT_SIZE - 1, WF_SEGMENT_SIZE);
+            nnzb_per_row = rocsparse::shfl(nnzb_per_row, WF_SEGMENT_SIZE - 1, WF_SEGMENT_SIZE);
 
             rocsparse_int k
                 = row_block_dim_C * col_block_dim_C * (bsr_row_start + nnzb_per_row - 1);

--- a/library/src/conversion/nnz_compress_device.h
+++ b/library/src/conversion/nnz_compress_device.h
@@ -82,7 +82,7 @@ namespace rocsparse
             count = rocsparse::wfreduce_sum<SEGMENT_SIZE>(count);
 
             // broadcast count from last thread in segment to all threads in segment
-            count = __shfl(count, SEGMENT_SIZE - 1, SEGMENT_SIZE);
+            count = rocsparse::shfl(count, SEGMENT_SIZE - 1, SEGMENT_SIZE);
 
             nnz_per_row[row_index] = count;
         }

--- a/library/src/conversion/prune_dense2csr_device.h
+++ b/library/src/conversion/prune_dense2csr_device.h
@@ -171,7 +171,7 @@ namespace rocsparse
 
                 // Broadcast the update of the shift to all 64 threads for the next set of 64 columns.
                 // Choose the last lane since that it contains the size of the sparse row (even if its predicate is false).
-                shift += __shfl(static_cast<int>(count_previous_nnzs), WF_SIZE - 1);
+                shift += rocsparse::shfl(static_cast<int>(count_previous_nnzs), WF_SIZE - 1);
             }
         }
     }

--- a/library/src/level2/rocsparse_bsrxmv_spzl_5x5.cpp
+++ b/library/src/level2/rocsparse_bsrxmv_spzl_5x5.cpp
@@ -94,7 +94,7 @@ namespace rocsparse
             f1 = fk;
 #pragma unroll 4
             for(int s = 1; s < block_size; ++s)
-                f1 = f1 + __shfl(fk, local_i + s * block_size, 32);
+                f1 = f1 + rocsparse::shfl(fk, local_i + s * block_size, 32);
 
             f1 = beta * y[global_row] + alpha * f1;
             if(local_j == 0)

--- a/library/src/level2/rocsparse_bsrxmv_spzl_8x8.cpp
+++ b/library/src/level2/rocsparse_bsrxmv_spzl_8x8.cpp
@@ -93,7 +93,7 @@ namespace rocsparse
             float f1 = fk;
 #pragma unroll 7
             for(int s = 1; s < 8; ++s)
-                f1 = f1 + __shfl(fk, local_i + s * block_size, 64);
+                f1 = f1 + rocsparse::shfl(fk, local_i + s * block_size, 64);
 
             f1 = beta * y[global_row] + alpha * f1;
             if(local_j == 0)

--- a/library/src/level3/coomm_device_segmented.h
+++ b/library/src/level3/coomm_device_segmented.h
@@ -306,7 +306,7 @@ namespace rocsparse
             {
 
                 const T v = rocsparse::shfl(val, i, WF_SIZE);
-                const I c = __shfl(col, i, WF_SIZE);
+                const I c = rocsparse::shfl(col, i, WF_SIZE);
 
                 if(!TRANSB)
                 {

--- a/library/src/level3/csrmm_device_nnz_split.h
+++ b/library/src/level3/csrmm_device_nnz_split.h
@@ -104,7 +104,7 @@ namespace rocsparse
             for(unsigned int i = 0; i < WF_SIZE; ++i)
             {
                 const T v = rocsparse::shfl(val, i, WF_SIZE);
-                const J c = __shfl(col_ind, i, WF_SIZE);
+                const J c = rocsparse::shfl(col_ind, i, WF_SIZE);
 
                 valB[i] = v * conj_val(dense_B[c + ldb * (colB + lid)], conj_B);
             }
@@ -249,7 +249,7 @@ namespace rocsparse
         for(unsigned int i = 0; i < WF_SIZE; ++i)
         {
             const T v = rocsparse::shfl(val, i, WF_SIZE);
-            const J c = __shfl(col_ind, i, WF_SIZE);
+            const J c = rocsparse::shfl(col_ind, i, WF_SIZE);
 
             valB[i] = (colB + lid) < N ? v * conj_val(dense_B[c + ldb * (colB + lid)], conj_B)
                                        : static_cast<T>(0);

--- a/library/src/precond/bsrilu0_device.h
+++ b/library/src/precond/bsrilu0_device.h
@@ -168,7 +168,7 @@ namespace rocsparse
                     if(match)
                     {
                         // Tell all other threads about the matching index
-                        rocsparse_int m = __shfl(q, match - 1);
+                        rocsparse_int m = rocsparse::shfl(q, match - 1);
 
                         // Load BSR block from row k into shared memory
                         sdata1[threadIdx.y][threadIdx.x]
@@ -477,7 +477,7 @@ namespace rocsparse
                     if(match)
                     {
                         // Tell all other threads about the matching index
-                        rocsparse_int m = __shfl(q, match - 1);
+                        rocsparse_int m = rocsparse::shfl(q, match - 1);
 
                         // Load BSR block from row k into shared memory
                         for(rocsparse_int p = threadIdx.x; p < block_dim; p += DIMX)
@@ -781,7 +781,7 @@ namespace rocsparse
                     if(match)
                     {
                         // Tell all other threads about the matching index
-                        rocsparse_int m = __shfl(q, match - 1);
+                        rocsparse_int m = rocsparse::shfl(q, match - 1);
 
                         // Load BSR block from row k into shared memory
                         for(rocsparse_int p = threadIdx.x; p < block_dim; p += DIMX)
@@ -1079,7 +1079,7 @@ namespace rocsparse
                     if(match)
                     {
                         // Tell all other threads about the matching index
-                        rocsparse_int m = __shfl(q, match - 1);
+                        rocsparse_int m = rocsparse::shfl(q, match - 1);
 
                         for(rocsparse_int bi = lid; bi < block_dim; bi += WFSIZE)
                         {

--- a/library/src/reordering/rocsparse_csrcolor.cpp
+++ b/library/src/reordering/rocsparse_csrcolor.cpp
@@ -172,7 +172,7 @@ namespace rocsparse
                 // Broadcast the update of the shift to all 64 threads for the next set of 64 columns.
                 // Choose the last lane since that it contains the size of the sparse row (even if its predicate is false).
                 //
-                shift += __shfl(static_cast<J>(count_previous_uncolored), WF_SIZE - 1);
+                shift += rocsparse::shfl(static_cast<J>(count_previous_uncolored), WF_SIZE - 1);
             }
         }
     }


### PR DESCRIPTION
Summary of proposed changes:
- In most case we call `rocsparse::shfl` but we still had some left over `__shfl` hanging around
- This PR replaces the `__shfl` with `rocsparse::shfl`
